### PR TITLE
Start ngrok on port 3000 if no PORT environment is defined

### DIFF
--- a/samples/tab-ui-templates/ts/gulpfile.js
+++ b/samples/tab-ui-templates/ts/gulpfile.js
@@ -130,7 +130,6 @@ task("manifest", series("generate-manifest", "schema-validation", "zip"));
 
 task("start-ngrok", (cb) => {
   log("[NGROK] starting ngrok...");
-  log(process.env.PORT);
   const ngrok = require("ngrok");
 
   const conf = {

--- a/samples/tab-ui-templates/ts/gulpfile.js
+++ b/samples/tab-ui-templates/ts/gulpfile.js
@@ -130,12 +130,13 @@ task("manifest", series("generate-manifest", "schema-validation", "zip"));
 
 task("start-ngrok", (cb) => {
   log("[NGROK] starting ngrok...");
+  log(process.env.PORT);
   const ngrok = require("ngrok");
 
   const conf = {
     subdomain: process.env.NGROK_SUBDOMAIN,
     region: process.env.NGROK_REGION,
-    addr: process.env.PORT,
+    addr: process.env.PORT !== undefined ? process.env.PORT : '3000',
     authtoken: process.env.NGROK_AUTH,
   };
 


### PR DESCRIPTION
# Overview

Whilst attempting to setup the sample app for myself I found that ngrok would point to the wrong port, this is because the default for ngrok when no port provided is `80`. This adds a simple check to see if `PORT` is defined, and if it isn't will instead default to `3000`

### Question
If a change like this were to be implemented, does it need to be implemented on all samples? 
I only changed it on the example provided here: https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/tab-ui-templates/ts. Which is referenced from here: https://github.com/OfficeDev/microsoft-teams-ui-component-library