### PR TITLE
Updated shebang.

### DIFF
--- a/samples/app-hello-world/nodejs/deploy.sh
+++ b/samples/app-hello-world/nodejs/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ----------------------
 # KUDU Deployment Script

--- a/samples/tab-sso/nodejs/deploy.sh
+++ b/samples/tab-sso/nodejs/deploy.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # ----------------------
 # KUDU Deployment Script


### PR DESCRIPTION
The advantage of using the this method is that it will search for
the bash executable in the user’s $PATH environmental variable.
Different *nixes put bash in different places, and using /usr/bin/env is
a workaround to run the first bash found on the PATH.