### PR TITLE
Rethrow to preserve stack details (CA2200)

### DIFF
--- a/samples/app-installation-using-qr-code/csharp/QRAppInstallation/SimpleGraphClient.cs
+++ b/samples/app-installation-using-qr-code/csharp/QRAppInstallation/SimpleGraphClient.cs
@@ -46,7 +46,7 @@ namespace QRAppInstallation
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             } 
         }
 

--- a/samples/bot-archive-groupchat-messages/csharp/FetchGroupChatMessages/helper/GetChatHelper.cs
+++ b/samples/bot-archive-groupchat-messages/csharp/FetchGroupChatMessages/helper/GetChatHelper.cs
@@ -33,7 +33,7 @@ namespace FetchGroupChatMessagesWithRSC.helper
             }
             catch (ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -90,7 +90,7 @@ namespace FetchGroupChatMessagesWithRSC.helper
             }
             catch (ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/bot-calling-meeting/csharp/Helpers/GraphHelper.cs
+++ b/samples/bot-calling-meeting/csharp/Helpers/GraphHelper.cs
@@ -137,7 +137,7 @@ namespace CallingBotSample.Helpers
                 catch (System.Exception ex)
                 {
 
-                    throw ex;
+                    throw;
                 }
             });
         }
@@ -208,7 +208,7 @@ namespace CallingBotSample.Helpers
                 }
                 catch (Exception ex)
                 {
-                    throw ex;
+                    throw;
                 }
             });
         }

--- a/samples/bot-join-team-using-qr-code/csharp/JoinTeamByQR/helper/JoinTeamHelper.cs
+++ b/samples/bot-join-team-using-qr-code/csharp/JoinTeamByQR/helper/JoinTeamHelper.cs
@@ -28,7 +28,7 @@ namespace JoinTeamByQR.helper
             }
             catch (ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/bot-sharepoint-file-viewer/csharp/BotWithSharePointFileViewer/helper/SharePointFileHelper.cs
+++ b/samples/bot-sharepoint-file-viewer/csharp/BotWithSharePointFileViewer/helper/SharePointFileHelper.cs
@@ -29,7 +29,7 @@ namespace BotWithSharePointFileViewer.helper
             }
             catch (ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/graph-proactive-installation/csharp/ProactiveAppInstallation/Models/ProactiveAppIntallationHelper.cs
+++ b/samples/graph-proactive-installation/csharp/ProactiveAppInstallation/Models/ProactiveAppIntallationHelper.cs
@@ -64,7 +64,7 @@ namespace ProactiveBot.Bots
                 {
                     await TriggerConversationUpdate(Userid, MicrosoftTenantId, MicrosoftAppId, MicrosoftAppPassword, MicrosoftTeamAppid);
                 }
-                else throw ex;
+                else throw;
             }
         }
 
@@ -91,7 +91,7 @@ namespace ProactiveBot.Bots
             }
             catch (Microsoft.Graph.ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/incoming-webhook/csharp/IncomingWebhook/Controllers/CardController.cs
+++ b/samples/incoming-webhook/csharp/IncomingWebhook/Controllers/CardController.cs
@@ -33,7 +33,7 @@ namespace IncomingWebhook.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -59,7 +59,7 @@ namespace IncomingWebhook.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/CandidateController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/CandidateController.cs
@@ -41,7 +41,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -66,7 +66,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/FeedbackController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/FeedbackController.cs
@@ -36,7 +36,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotesController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotesController.cs
@@ -55,7 +55,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -75,7 +75,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotifyController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotifyController.cs
@@ -107,7 +107,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/QuestionController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/QuestionController.cs
@@ -39,7 +39,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -60,7 +60,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -81,7 +81,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -101,7 +101,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meetings-live-code-interview/csharp/MeetingLiveCoding/Controllers/MeetingController.cs
+++ b/samples/meetings-live-code-interview/csharp/MeetingLiveCoding/Controllers/MeetingController.cs
@@ -62,7 +62,7 @@ namespace MeetingLiveCoding.Controllers
                 }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -112,7 +112,7 @@ namespace MeetingLiveCoding.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }


### PR DESCRIPTION
Stack trace is lost with the current samples.

Arguably these exceptions could be left uncaught to bubble up, but I'm assuming that they're in to make debugging and setting breakpoints easier so I've not removed them