### PR TITLE
Fix duplicate API calls, and some styling mismatches

### DIFF
--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/.storybook/main.js
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/.storybook/main.js
@@ -1,20 +1,17 @@
 module.exports = {
-  stories: [
-    '../src/**/*.stories.mdx',
-    '../src/**/*.stories.@(js|jsx|ts|tsx)'
-  ],
+  stories: ['../src/**/*.stories.mdx', '../src/**/*.stories.@(js|jsx|ts|tsx)'],
   addons: [
     '@storybook/addon-links',
     '@storybook/addon-essentials',
-    '@storybook/preset-create-react-app'
+    '@storybook/preset-create-react-app',
   ],
   framework: '@storybook/react',
   core: {
-    builder: 'webpack5'
+    builder: 'webpack5',
   },
   webpackFinal: (config) => {
-      config.resolve.modules = [...(config.resolve.modules || []), './src']
+    config.resolve.modules = [...(config.resolve.modules || []), './src'];
 
-      return config
+    return config;
   },
-}
+};

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/.storybook/preview.js
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/.storybook/preview.js
@@ -1,16 +1,26 @@
-import { withTeamsThemeProvider } from "../src/utils/TeamsProvider/TeamsProvider";
+import { withTeamsThemeProvider } from '../src/utils/TeamsProvider/MockTeamsProvider';
 
 export const parameters = {
-    actions: { argTypesRegex: "^on[A-Z].*" },
-    controls: {
-        matchers: {
-            color: /(background|color)$/i,
-            date: /Date$/,
-        },
+  actions: { argTypesRegex: '^on[A-Z].*' },
+  controls: {
+    matchers: {
+      color: /(background|color)$/i,
+      date: /Date$/,
     },
+  },
 };
 
-export const decorators = [
-    (story) =>
-        withTeamsThemeProvider({ story }),
-];
+export const globalTypes = {
+  theme: {
+    name: 'Teams Theme',
+    description: 'Teams theme for components',
+    defaultValue: 'default',
+    toolbar: {
+      icon: 'lightning',
+      items: ['default', 'dark', 'contrast'],
+      showName: true,
+    },
+  },
+};
+
+export const decorators = [(story, context) => withTeamsThemeProvider({ story, context })];

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/package-lock.json
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/package-lock.json
@@ -22,6 +22,7 @@
         "lodash": "^4.17.21",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-query": "^3.39.0",
         "react-router-dom": "^6.0.2",
         "react-scripts": "5.0.0",
         "typescript": "^4.1.2",
@@ -46,7 +47,6 @@
         "eslint-plugin-prettier": "^4.0.0",
         "eslint-plugin-react": "^7.28.0",
         "eslint-plugin-react-hooks": "^4.3.0",
-        "eslint-plugin-sonarjs": "^0.11.0",
         "webpack": "^5.68.0"
       }
     },
@@ -13378,7 +13378,6 @@
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
       "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "peer": true,
       "engines": {
         "node": ">=0.6"
       }
@@ -13540,6 +13539,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/brorand": {
@@ -16858,18 +16872,6 @@
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "bin": {
         "semver": "bin/semver.js"
-      }
-    },
-    "node_modules/eslint-plugin-sonarjs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.11.0.tgz",
-      "integrity": "sha512-ei/WuZiL0wP+qx2KrxKyZs3+eDbxiGAhFSm3GKCOOAUkg+G2ny6TSXDB2j67tvyqHefi+eoQsAgGQvz+nEtIBw==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0|| ^8.0.0"
       }
     },
     "node_modules/eslint-plugin-testing-library": {
@@ -22868,6 +22870,11 @@
         "node": ">= 10.13.0"
       }
     },
+    "node_modules/js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "node_modules/js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -23382,6 +23389,15 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -23566,6 +23582,11 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
@@ -23828,6 +23849,14 @@
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
       "dev": true,
       "optional": true
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.2.0",
@@ -24361,6 +24390,11 @@
       "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
       "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
       "dev": true
+    },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/obuf": {
       "version": "1.1.2",
@@ -25886,6 +25920,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
+      }
+    },
+    "node_modules/react-query": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.0.tgz",
+      "integrity": "sha512-Od0IkSuS79WJOhzWBx/ys0x13+7wFqgnn64vBqqAAnZ9whocVhl/y1padD5uuZ6EIkXbFbInax0qvY7zGM0thA==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-refresh": {
@@ -28958,6 +29017,11 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
@@ -31880,6 +31944,15 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unpipe": {
@@ -43599,8 +43672,7 @@
     "big-integer": {
       "version": "1.6.51",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz",
-      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==",
-      "peer": true
+      "integrity": "sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -43736,6 +43808,21 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "brorand": {
@@ -46448,13 +46535,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.3.0.tgz",
       "integrity": "sha512-XslZy0LnMn+84NEG9jSGR6eGqaZB3133L8xewQo3fQagbQuGt7a63gf+P1NGKZavEYEC3UXaWEAA/AqDkuN6xA==",
-      "requires": {}
-    },
-    "eslint-plugin-sonarjs": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-0.11.0.tgz",
-      "integrity": "sha512-ei/WuZiL0wP+qx2KrxKyZs3+eDbxiGAhFSm3GKCOOAUkg+G2ny6TSXDB2j67tvyqHefi+eoQsAgGQvz+nEtIBw==",
-      "dev": true,
       "requires": {}
     },
     "eslint-plugin-testing-library": {
@@ -50895,6 +50975,11 @@
         "supports-color": "^7.0.0"
       }
     },
+    "js-sha3": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
+      "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q=="
+    },
     "js-string-escape": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/js-string-escape/-/js-string-escape-1.0.1.tgz",
@@ -51297,6 +51382,15 @@
       "dev": true,
       "requires": {}
     },
+    "match-sorter": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
+      "integrity": "sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -51443,6 +51537,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -51655,6 +51754,14 @@
       "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
       "dev": true,
       "optional": true
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoid": {
       "version": "3.2.0",
@@ -52081,6 +52188,11 @@
       "resolved": "https://registry.npmjs.org/objectorarray/-/objectorarray-1.0.5.tgz",
       "integrity": "sha512-eJJDYkhJFFbBBAxeh8xW+weHlkI28n2ZdQV/J/DNfWfSKlGEf2xcfAbZTv3riEXHAhL9SVOTs2pRmXiSTf78xg==",
       "dev": true
+    },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "obuf": {
       "version": "1.1.2",
@@ -53235,6 +53347,16 @@
           "integrity": "sha512-92FRmppjjqz29VMJ2dn+xdyXZBrMlE42AV6Kq6BwjWV7CNUW1hs2FtxSNLQE+gJhaZ6AAmYuO9y8dshhcBl7vA==",
           "dev": true
         }
+      }
+    },
+    "react-query": {
+      "version": "3.39.0",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.0.tgz",
+      "integrity": "sha512-Od0IkSuS79WJOhzWBx/ys0x13+7wFqgnn64vBqqAAnZ9whocVhl/y1padD5uuZ6EIkXbFbInax0qvY7zGM0thA==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
       }
     },
     "react-refresh": {
@@ -55254,6 +55376,11 @@
       "requires": {
         "mdast-squeeze-paragraphs": "^4.0.0"
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -57523,6 +57650,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/package.json
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/package.json
@@ -17,6 +17,7 @@
     "lodash": "^4.17.21",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-query": "^3.39.0",
     "react-router-dom": "^6.0.2",
     "react-scripts": "5.0.0",
     "typescript": "^4.1.2",
@@ -31,6 +32,22 @@
     "lint:fix": "eslint --fix ./src",
     "storybook": "start-storybook -p 6006 -s public",
     "build-storybook": "build-storybook -s public"
+  },
+  "eslintConfig": {
+    "extends": [
+      "react-app",
+      "react-app/jest"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "**/*.stories.*"
+        ],
+        "rules": {
+          "import/no-anonymous-default-export": "off"
+        }
+      }
+    ]
   },
   "browserslist": {
     "production": [
@@ -63,7 +80,6 @@
     "eslint-plugin-prettier": "^4.0.0",
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
-    "eslint-plugin-sonarjs": "^0.11.0",
     "webpack": "^5.68.0"
   }
 }

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/App.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/App.tsx
@@ -1,7 +1,6 @@
 import { Outlet, Route, Routes } from 'react-router-dom';
 import { Flex, FlexItem } from '@fluentui/react-northstar';
 import { useDefaultColorScheme } from 'hooks';
-import { AuthProvider } from './utils/AuthProvider';
 import Home from 'routes/Home';
 import { DocumentStage } from 'components/DocumentStage';
 import Configure from 'routes/Configure';
@@ -13,20 +12,18 @@ export default function App() {
   const appInlineStyles = { backgroundColor: colorScheme.background };
 
   return (
-    <AuthProvider>
-      <Flex column={true} styles={appInlineStyles}>
-        <FlexItem>
-          <Routes>
-            <Route path="/" element={<Outlet />}>
-              <Route index element={<Home />} />
-              <Route path="configure" element={<Configure />} />
-              <Route path="stage/:documentId" element={<DocumentStage />} />
-              <Route path="auth-start" element={<AuthStart />} />
-              <Route path="auth-end" element={<AuthEnd />} />
-            </Route>
-          </Routes>
-        </FlexItem>
-      </Flex>
-    </AuthProvider>
+    <Flex column styles={appInlineStyles}>
+      <FlexItem>
+        <Routes>
+          <Route path="/" element={<Outlet />}>
+            <Route index element={<Home />} />
+            <Route path="configure" element={<Configure />} />
+            <Route path="stage/:documentId" element={<DocumentStage />} />
+            <Route path="auth-start" element={<AuthStart />} />
+            <Route path="auth-end" element={<AuthEnd />} />
+          </Route>
+        </Routes>
+      </FlexItem>
+    </Flex>
   );
 }

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/api/documentApi.ts
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/api/documentApi.ts
@@ -1,22 +1,19 @@
-import { DocumentInput } from 'models';
-import fetchClient from './fetchClient';
+import { Document, DocumentInput } from 'models';
+import { authFetch } from './fetchClient';
 
-const getDocument = (token: string, documentId: string): Promise<Response> => {
-  return fetchClient(token, `document/${documentId}/`, { method: 'GET' });
+async function getDocument(documentId: string) {
+  return await authFetch<Document>(`document/${documentId}/`, { method: 'GET' });
 };
 
-const getAllDocuments = (token: string): Promise<Response> => {
-  return fetchClient(token, 'document', { method: 'GET' });
+async function getAllDocuments() {
+  return await authFetch<Document[]>('document', { method: 'GET' });
 };
 
-const createDocument = (
-  token: string,
-  document: DocumentInput,
-): Promise<Response> => {
-  return fetchClient(token, 'document', {
+async function createDocument(document: DocumentInput) {
+  return await authFetch<Document>('document', {
     method: 'POST',
     body: JSON.stringify(document),
   });
 };
 
-export default { getDocument, getAllDocuments, createDocument };
+export { getDocument, getAllDocuments, createDocument };

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/api/fetchClient.ts
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/api/fetchClient.ts
@@ -1,27 +1,68 @@
 import { merge } from 'lodash';
+import { ApiErrorResponse, ErrorCode } from 'models/ApiErrorResponse';
+import * as microsoftTeams from '@microsoft/teams-js';
 
-export default async function authFetch(
-  token: string,
+// This function is for callers where authentication is required.
+// It makes a fetch client call with an AAD token.
+export async function authFetch<T>(
   urlPath: string,
   init?: RequestInit,
-): Promise<Response> {
-  const headers = createHeaders(token, init?.headers);
+) {
+  const token = await getAuthToken().catch((err) => {
+    throw new Error(`Unable to get Auth token ${err}`);
+  });
 
   const mergedInit = merge({}, init, {
-    credentials: 'same-origin',
-    headers,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json, text/plain',
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
   });
-
-  return fetch(`/${urlPath}`, mergedInit);
+  return (await fetchClient(urlPath, mergedInit)) as T;
 }
 
-export function createHeaders(
-  token: string,
-  initHeaders?: HeadersInit,
-): HeadersInit {
-  return merge({}, initHeaders, {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/json, text/plain',
-    'Content-Type': 'application/json;charset=UTF-8',
+async function getAuthToken() {
+  return new Promise<string>((resolve, reject) => {
+    microsoftTeams.authentication.getAuthToken({
+      successCallback: (token) => {
+        resolve(token);
+      },
+      failureCallback: (reason) => {
+        reject(reason);
+      },
+    });
   });
+}
+
+async function fetchClient(
+  urlPath: string,
+  mergedInit: RequestInit,
+) {
+  const response = await fetch(`/${urlPath}`, mergedInit);
+
+  if (!response.ok) {
+    const errorJson: ApiErrorResponse = await response.json();
+    if (!errorJson) {
+      throw new Error('Error fetching data.');
+    }
+
+    if (errorJson.ErrorCode === ErrorCode.AuthConsentRequired) {
+      microsoftTeams.authentication.authenticate({
+        url: `${window.location.origin}/auth-start`,
+        width: 600,
+        height: 535,
+        successCallback: async (result) => {
+          console.log('Consent provided.');
+          return await fetchClient(urlPath, mergedInit);
+        },
+        failureCallback: (error) => {
+          console.error("Failed to get consent: '" + error + "'");
+        },
+      });
+    }
+
+    throw new Error(`${errorJson.ErrorCode}: ${errorJson.Message}`);
+  }
+  return await response.json();
 }

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/api/signatureApi.ts
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/api/signatureApi.ts
@@ -1,15 +1,23 @@
 import { Signature } from 'models';
-import fetchClient from './fetchClient';
+import { authFetch } from './fetchClient';
 
-const postSignDocument = (
-  token: string,
-  documentId: string,
-  signature: Signature,
-): Promise<Response> => {
-  return fetchClient(token, `document/${documentId}/sign`, {
+
+// React-Query has a limitation of only allowing one variable for mutations
+// To solve this limitation, we merge the documentId and SignDocumentModel for postSignDocument
+// It is kept separate from the other models in /models because it is not to be used except in this situation.
+type SignDocumentModel = {
+  documentId: string;
+  signature: Signature;
+};
+
+async function postSignDocument(
+  model: SignDocumentModel,
+) {
+  return await authFetch<Signature>(`document/${model.documentId}/sign`, {
     method: 'POST',
-    body: JSON.stringify(signature),
+    body: JSON.stringify(model.signature),
   });
 };
 
-export default { postSignDocument };
+export { postSignDocument };
+export type { SignDocumentModel };

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/Documents/DocumentChooser.stories.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/Documents/DocumentChooser.stories.tsx
@@ -15,7 +15,7 @@ const Template: ComponentStory<typeof DocumentChooser> = (args) => (
 export const PurchaseAgreementDocument = Template.bind({});
 PurchaseAgreementDocument.args = {
   documentType: DocumentType.PurchaseAgreement,
-  loggedInAadId: '00000000-0000-0000-0000-000000000001', // eslint-disable-line sonarjs/no-duplicate-string
+  loggedInAadId: '00000000-0000-0000-0000-000000000001',
   signatures: [
     {
       signer: {

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/SidepanelDocumentCard/SidepanelDocumentCard.module.css
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/SidepanelDocumentCard/SidepanelDocumentCard.module.css
@@ -7,4 +7,5 @@
   max-height: 20rem;
   white-space: nowrap;
   font-size: 0.65rem;
+  box-shadow: 0 -2rem 2rem -2rem rgba(0,0,0,0.6) inset;
 }

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/SidepanelDocumentCard/SidepanelDocumentCard.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/SidepanelDocumentCard/SidepanelDocumentCard.tsx
@@ -39,9 +39,7 @@ export function SidepanelDocumentCard({
   const stateColor: string =
     documentState === DocumentState.Active
       ? theme.siteVariables.naturalColors.green['200']
-      : documentState === DocumentState.Complete
-      ? theme.siteVariables.naturalColors.yellow['500']
-      : theme.siteVariables.naturalColors.grey['600'];
+      : theme.siteVariables.naturalColors.grey['500'];
   const cardInlineStyles = { borderTopColor: stateColor };
 
   const shareToStageCallback = (
@@ -70,12 +68,19 @@ export function SidepanelDocumentCard({
         <Card.Header>
           <Flex vAlign="center">
             <div>
-              <Badge content="Active" backgroundColor={stateColor} />
+              <Badge
+                content={DocumentState[documentState]}
+                backgroundColor={stateColor}
+              />
             </div>
             <Flex.Item push>
               <div>
                 <Badge
-                  content="Unsigned Document"
+                  content={
+                    documentState === DocumentState.Complete
+                      ? 'Signed document'
+                      : 'Unsigned document'
+                  }
                   size="small"
                   rectangular
                   backgroundColor="#616161"

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/SidepanelDocumentCardList/SidepanelDocumentCardList.stories.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/SidepanelDocumentCardList/SidepanelDocumentCardList.stories.tsx
@@ -18,7 +18,7 @@ DocumentCardList.args = {
       id: '12300000-0000-0000-0000-000000000001',
       documentType: DocumentType.PurchaseAgreement,
       documentState: 'active',
-      loggedInAadId: '00000000-0000-0000-0000-000000000001', // eslint-disable-line sonarjs/no-duplicate-string
+      loggedInAadId: '00000000-0000-0000-0000-000000000001',
       signatures: [
         {
           signer: {

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/TabContent/TabContent.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/components/TabContent/TabContent.tsx
@@ -3,11 +3,11 @@ import * as microsoftTeams from '@microsoft/teams-js';
 import { TaskInfo } from '@microsoft/teams-js';
 import * as ACData from 'adaptivecards-templating';
 import { CreateDocumentCard } from 'adaptive-cards';
-import documentApi from 'api/documentApi';
+import { createDocument } from 'api/documentApi';
 import { useTeamsContext } from 'utils/TeamsProvider/hooks';
-import { useApi } from 'hooks';
-import { DocumentInput, DocumentType, User } from 'models';
+import { Document, DocumentInput, DocumentType, User } from 'models';
 import styles from './TabContent.module.css';
+import { useMutation } from 'react-query';
 
 type Choice = {
   name: string;
@@ -22,7 +22,14 @@ type Choice = {
  */
 export function TabContent() {
   const context = useTeamsContext();
-  const createDocumentApi = useApi(documentApi.createDocument);
+
+  const createDocumentMutation = useMutation<
+    Document,
+    Error,
+    DocumentInput
+  >((documentInput: DocumentInput) =>
+    createDocument(documentInput),
+  );
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const createTaskInfo = (card: any): TaskInfo => {
@@ -77,7 +84,7 @@ export function TabContent() {
             signers: signers,
           };
 
-          await createDocumentApi.request(documentInput);
+          createDocumentMutation.mutate(documentInput);
         });
       }
     };
@@ -89,7 +96,7 @@ export function TabContent() {
   };
 
   return (
-    <Flex column={true} className={styles.tabContent}>
+    <Flex column className={styles.tabContent}>
       <Header
         as="h2"
         content="Meeting Signing, sharing to stage programmatically"
@@ -102,15 +109,15 @@ export function TabContent() {
         onClick={() => createDocumentsTaskModule()}
         primary
       />
-      {createDocumentApi.error && (
+      {createDocumentMutation.isError && (
         <Alert
           header="Error"
-          content={createDocumentApi.error}
+          content={createDocumentMutation.error}
           danger
           visible
         />
       )}
-      {createDocumentApi.data && (
+      {createDocumentMutation.data && (
         <Alert header="Success" content="Document Created" success visible />
       )}
     </Flex>

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/hooks/index.ts
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/hooks/index.ts
@@ -1,8 +1,6 @@
-import { useApi } from './useApi';
 import {
   useTheme,
   useDefaultColorScheme,
   useColorScheme,
 } from './useColorScheme';
-import { useInterval } from './useInterval';
-export { useApi, useTheme, useDefaultColorScheme, useColorScheme, useInterval };
+export { useTheme, useDefaultColorScheme, useColorScheme };

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/index.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/index.tsx
@@ -1,17 +1,22 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import * as microsoftTeams from '@microsoft/teams-js';
 import './index.css';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { TeamsProvider } from 'utils/TeamsProvider/TeamsProvider';
 
+const queryClient = new QueryClient();
+
 ReactDOM.render(
   <React.StrictMode>
     <TeamsProvider microsoftTeams={microsoftTeams}>
       <BrowserRouter>
-        <App />
+        <QueryClientProvider client={queryClient}>
+          <App />
+        </QueryClientProvider>
       </BrowserRouter>
     </TeamsProvider>
   </React.StrictMode>,

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/utils/TeamsProvider/MockTeamsProvider.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/utils/TeamsProvider/MockTeamsProvider.tsx
@@ -1,0 +1,43 @@
+import * as microsoftTeams from '@microsoft/teams-js';
+import { Context } from '@microsoft/teams-js';
+import { Story } from '@storybook/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { TeamsProvider } from './TeamsProvider';
+
+export type TeamsThemeProviderProps = {
+  context: any;
+  story: Story;
+};
+
+export const withTeamsThemeProvider = (
+  props: TeamsThemeProviderProps,
+): React.ReactElement => {
+  let mockedMicrosoftTeams: typeof microsoftTeams = {
+    ...microsoftTeams,
+    initialize: (callback?: ((value: unknown) => void) | undefined) => {
+      if (callback) {
+        return callback('Done');
+      }
+    },
+    getContext: (callback: (context: Context) => void) => {
+      callback({
+        entityId: '',
+        locale: '',
+        theme: 'default',
+      });
+    },
+    registerOnThemeChangeHandler: (handler: (theme: string) => void) => {
+      handler(props.context.globals.theme);
+    },
+  };
+
+  const queryClient = new QueryClient();
+
+  return (
+    <TeamsProvider microsoftTeams={mockedMicrosoftTeams}>
+      <QueryClientProvider client={queryClient}>
+        {<props.story />}
+      </QueryClientProvider>
+    </TeamsProvider>
+  );
+};

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/utils/TeamsProvider/TeamsProvider.tsx
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/utils/TeamsProvider/TeamsProvider.tsx
@@ -8,12 +8,11 @@ import {
   Provider as FluentUiProvider,
   ThemeInput,
 } from '@fluentui/react-northstar';
-import { Story } from '@storybook/react';
 
 export interface TeamsProviderContext {
   context: Context;
   microsoftTeams: typeof microsoftTeams;
-  initializePromise: Promise<void>;
+  initializePromise: Promise<unknown>;
   setContext: (ctx: Context) => void;
 }
 
@@ -45,7 +44,7 @@ export const themeMap: { [key: string]: ThemeInput } = {
 };
 
 export function getTheme(theme?: string): ThemeInput {
-  const key = theme && theme in themeMap ? theme : 'dark';
+  const key = theme && theme in themeMap ? theme : 'default';
   return themeMap[key];
 }
 
@@ -61,7 +60,17 @@ export function TeamsProvider({
   };
   const [context, setContext] = useState<Context>(contextInit);
   const initializePromise = useMemo(
-    () => new Promise<void>((resolve) => microsoftTeams.initialize(resolve)),
+    () =>
+      Promise.race([
+        new Promise<void>((resolve) => microsoftTeams.initialize(resolve)),
+        new Promise((resolve, reject) =>
+          setTimeout(
+            () =>
+              reject('Failed to initialize connection with Microsoft Teams'),
+            1000,
+          ),
+        ),
+      ]),
     [microsoftTeams],
   );
 
@@ -89,17 +98,3 @@ export function TeamsProvider({
     </TeamsContext.Provider>
   );
 }
-
-export type TeamsThemeProviderProps = {
-  story: Story;
-};
-
-export const withTeamsThemeProvider = (
-  props: TeamsThemeProviderProps,
-): React.ReactElement => {
-  return (
-    <TeamsProvider microsoftTeams={microsoftTeams}>
-      {<props.story />}
-    </TeamsProvider>
-  );
-};

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/utils/TeamsProvider/hooks.ts
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/ClientApp/src/utils/TeamsProvider/hooks.ts
@@ -3,44 +3,6 @@ import { Context } from '@microsoft/teams-js';
 import { useContext, useMemo } from 'react';
 import { TeamsContext, getTheme } from './TeamsProvider';
 
-/**
- * Create a deferred version of the function that captures the parameters on execution, but only
- * calls the function after the provided promise resolves successfully.
- *
- * This is useful for ensuring 'initialization' calls complete before attempting to access API calls such
- * as the 'initialization' call for Microsoft Teams.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function deferAfter<T extends (...args: any[]) => void>(
-  promise: Promise<void>,
-  fn: T,
-) {
-  return function (...params: Parameters<T>) {
-    promise.then(() => {
-      fn(...params);
-    });
-  };
-}
-
-/**
- * Create a hook for getting a callback for microsoft teams such as notifySuccess or executeDeeplink.
- * Hooks created through this call ensure that the teams context is initialized before attempting to
- * call the underlying callback.
- */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function createInitDeferredCallbackHook<T extends (...args: any[]) => void>(
-  getter: (teams: typeof microsoftTeams) => T,
-) {
-  return function () {
-    const providerContext = useContext(TeamsContext);
-    const cb = getter(providerContext.microsoftTeams);
-    return useMemo(
-      () => deferAfter(providerContext.initializePromise, cb),
-      [providerContext.initializePromise, cb],
-    );
-  };
-}
-
 export function useTeamsContext(): Context {
   const providerContext = useContext(TeamsContext);
   // trigger context refresh?
@@ -57,15 +19,3 @@ export function useTheme(): ThemeInput {
   const ctx = useTeamsContext();
   return useMemo(() => getTheme(ctx.theme), [ctx.theme]);
 }
-
-export const useExecuteDeepLink = createInitDeferredCallbackHook(
-  (teams) => teams.executeDeepLink,
-);
-
-export const useNotifyAppLoaded = createInitDeferredCallbackHook(
-  (teams) => teams.appInitialization.notifyAppLoaded,
-);
-
-export const useNotifySuccess = createInitDeferredCallbackHook(
-  (teams) => teams.appInitialization.notifySuccess,
-);

--- a/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/Manifest/manifest.json
+++ b/samples/meetings-share-to-stage-signing/csharp/Source/MeetingSigning.Web/Manifest/manifest.json
@@ -29,7 +29,6 @@
       "configurationUrl": "https://<<deployment-url>>/configure",
       "canUpdateConfiguration": true,
       "scopes": [
-        "team",
         "groupchat"
       ],
       "context": [


### PR DESCRIPTION
Fixes some issues called out by internal testing.

Mainly the API being called multiple times leading to odd errors, and some styling issues that were called out.

The cause of the duplicates calls is down to bugs in the sample's AuthProvider component. AuthProvider would cache the response of the getAuthToken, and it would then pass the token around to make the call. (This is a pattern that our docs explicitly say we shouldn't do). If the API call didn't work or was missing a token it would try to get a new token and call again based on several statuses. This along with the useApi and fetchClient was a dodgy solution that "worked" in some cases, but not in general.

I've changed all of this, instead I'm using react-query instead of the useApi code, the fetchClient was updated to instead get the authToken at the time we call the API (which is what we should always do instead of caching according to the docs).