### PR TITLE
Reverted manifest schema for few samples using RSC permissions

### DIFF
--- a/samples/bot-receive-channel-messages-withRSC/csharp/ReceiveMessagesWithRSC/AppManifest/manifest.json
+++ b/samples/bot-receive-channel-messages-withRSC/csharp/ReceiveMessagesWithRSC/AppManifest/manifest.json
@@ -1,6 +1,6 @@
 ﻿{
-  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.12/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.12",
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.11/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.11",
   "version": "1.0.0",
   "id": "3214cc0a-f062-42c5-85c8-d8bb1dd12f21",
   "packageName": "com.microsoft.teams.botrsc",

--- a/samples/bot-receive-channel-messages-withRSC/nodejs/appPackage/manifest.json
+++ b/samples/bot-receive-channel-messages-withRSC/nodejs/appPackage/manifest.json
@@ -1,6 +1,6 @@
 ﻿{
-  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.12/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.12",
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.11/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.11",
   "version": "1.0.0",
   "id": "<<MANIFEST-ID>>",
   "packageName": "com.microsoft.teams.botrsc",

--- a/samples/meetings-events/csharp/MeetingEvents/AppPackage/manifest.json
+++ b/samples/meetings-events/csharp/MeetingEvents/AppPackage/manifest.json
@@ -1,6 +1,6 @@
 ﻿{
-  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.12/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.12",
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.11/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.11",
   "version": "1.0.0",
   "id": "<<APP-ID>>",
   "packageName": "com.microsoft.teams.botmeetingevents",

--- a/samples/meetings-events/nodejs/appPackage/manifest.json
+++ b/samples/meetings-events/nodejs/appPackage/manifest.json
@@ -1,6 +1,6 @@
 ﻿{
-  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.12/MicrosoftTeams.schema.json",
-  "manifestVersion": "1.12",
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/teams/v1.11/MicrosoftTeams.schema.json",
+  "manifestVersion": "1.11",
   "version": "1.0.0",
   "id": "<<APP-ID>>",
   "packageName": "com.microsoft.teams.botmeetingevents",


### PR DESCRIPTION
The samples with issues are

meetings-events/nodejs
‎meetings-events/csharp
bot-receive-channel-messages-withRSC/nodejs
bot-receive-channel-messages-withRSC/csharp