### PR TITLE
Fix ngrok `--host-header` parameter

### DIFF
--- a/samples/app-sso/nodejs/README.md
+++ b/samples/app-sso/nodejs/README.md
@@ -85,7 +85,7 @@ Create [Bot Framework registration resource](https://docs.microsoft.com/en-us/az
 1. Run ngrok - point to port `3978`
 
     ```bash
-    ngrok http -host-header=localhost 3978
+    ngrok http --host-header=localhost 3978
     ```
 
 


### PR DESCRIPTION
Per https://ngrok.com/docs/secure-tunnels#http-tunnels-host-header,
it is `--host-header` not `-host-header`.