### PR TITLE
Pins MGT CDN reference to v2

### DIFF
--- a/samples/graph-activity-feed-broadcast/nodejs/views/BroadcastDetails.ejs
+++ b/samples/graph-activity-feed-broadcast/nodejs/views/BroadcastDetails.ejs
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+        <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
         <script src="https://res.cdn.office.net/teams-js/2.1.0/js/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>

--- a/samples/tab-graph-toolkit/nodejs/public/auth.html
+++ b/samples/tab-graph-toolkit/nodejs/public/auth.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
   </head>
 
   <body>

--- a/samples/tab-request-approval/csharp/TabRequestApproval/Views/Home/Index.cshtml
+++ b/samples/tab-request-approval/csharp/TabRequestApproval/Views/Home/Index.cshtml
@@ -3,7 +3,7 @@
 <html lang="en">
    <head>
         <script src="https://unpkg.com/@@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+        <script src="https://unpkg.com/@@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
         <script src="https://statics.teams.cdn.office.net/sdk/v1.6.0/js/MicrosoftTeams.min.js"
             integrity="sha384-mhp2E+BLMiZLe7rDIzj19WjgXJeI32NkPvrvvZBrMi5IvWup/1NUfS5xuYN5S3VT"

--- a/samples/tab-request-approval/csharp/TabRequestApproval/Views/Home/TabAuth.cshtml
+++ b/samples/tab-request-approval/csharp/TabRequestApproval/Views/Home/TabAuth.cshtml
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <script src="https://unpkg.com/@@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <script src="https://unpkg.com/@@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
 </head>
 
 <body>

--- a/samples/tab-request-approval/nodejs/views/UserNotification.ejs
+++ b/samples/tab-request-approval/nodejs/views/UserNotification.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+        <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
         <script src="https://statics.teams.cdn.office.net/sdk/v1.6.0/js/MicrosoftTeams.min.js"
             integrity="sha384-mhp2E+BLMiZLe7rDIzj19WjgXJeI32NkPvrvvZBrMi5IvWup/1NUfS5xuYN5S3VT"

--- a/samples/tab-request-approval/nodejs/views/UserRequest.ejs
+++ b/samples/tab-request-approval/nodejs/views/UserRequest.ejs
@@ -2,7 +2,7 @@
 <html lang="en">
     <head>
         <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-        <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+        <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.1/css/bootstrap.min.css">
         <script src="https://statics.teams.cdn.office.net/sdk/v1.6.0/js/MicrosoftTeams.min.js"
             integrity="sha384-mhp2E+BLMiZLe7rDIzj19WjgXJeI32NkPvrvvZBrMi5IvWup/1NUfS5xuYN5S3VT"

--- a/samples/tab-request-approval/nodejs/views/tabAuth.ejs
+++ b/samples/tab-request-approval/nodejs/views/tabAuth.ejs
@@ -1,7 +1,7 @@
 <html>
   <head>
     <script src="https://unpkg.com/@microsoft/teams-js/dist/MicrosoftTeams.min.js" crossorigin="anonymous"></script>
-    <script src="https://unpkg.com/@microsoft/mgt/dist/bundle/mgt-loader.js"></script>
+    <script src="https://unpkg.com/@microsoft/mgt@2/dist/bundle/mgt-loader.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
Pins MGT CDN reference to v2 so that samples will keep working when MGT v3 becomes the latest version later this year.