### PR TITLE
chore(teamsfx): use example values for developer urls in bot proactive messaging sample

### DIFF
--- a/samples/bot-proactive-messaging-teamsfx/templates/appPackage/manifest.template.json
+++ b/samples/bot-proactive-messaging-teamsfx/templates/appPackage/manifest.template.json
@@ -6,9 +6,9 @@
     "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
-        "websiteUrl": "{{{state.fx-resource-frontend-hosting.endpoint}}}",
-        "privacyUrl": "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/privacy",
-        "termsOfUseUrl": "{{{state.fx-resource-frontend-hosting.endpoint}}}{{{state.fx-resource-frontend-hosting.indexPath}}}/termsofuse"
+        "websiteUrl": "https://www.example.com",
+        "privacyUrl": "https://www.example.com/privacy",
+        "termsOfUseUrl": "https://www.example.com/termsofuse"
     },
     "icons": {
         "color": "resources/color.png",


### PR DESCRIPTION
The placeholders for developer urls in existing template are hard to understand and customize. Changing them to example values so users can customize them easier.