### PR TITLE
Fix file path compatibility for Unix-based systems

### DIFF
--- a/samples/bot-adaptivecards-user-specific-views/csharp/Microsoft.Teams.Samples.UserSpecificViews/Cards/CardFactory.cs
+++ b/samples/bot-adaptivecards-user-specific-views/csharp/Microsoft.Teams.Samples.UserSpecificViews/Cards/CardFactory.cs
@@ -17,10 +17,10 @@ namespace Microsoft.Teams.Samples.UserSpecificViews.Cards
     /// </summary>
     public class CardFactory : ICardFactory
     {
-        private const string SelectCardTypeCardTemplatePath = "{0}\\assets\\templates\\select-card-type.json";
-        private const string RefreshSpecificUserViewCardTemplatePath = "{0}\\assets\\templates\\refresh-specific-user.json";
-        private const string RefreshAllUsersViewCardTemplatePath = "{0}\\assets\\templates\\refresh-all-users.json";
-        private const string UpdatedBaseCardTemplatePath = "{0}\\assets\\templates\\updated-base-card.json";
+        private static readonly string SelectCardTypeCardTemplatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "templates", "select-card-type.json");
+        private static readonly string RefreshSpecificUserViewCardTemplatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "templates", "refresh-specific-user.json");
+        private static readonly string RefreshAllUsersViewCardTemplatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "templates", "refresh-all-users.json");
+        private static readonly string UpdatedBaseCardTemplatePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "assets", "templates", "updated-base-card.json");
 
         private const string BaseCardStatus = "Base";
         private const string UpdatedCardStatus = "Updated";
@@ -103,7 +103,7 @@ namespace Microsoft.Teams.Samples.UserSpecificViews.Cards
             return CreateAttachment(serializedJson);
         }
 
-        
+
 
         /// <inheritdoc/>
         public Attachment GetFinalBaseCard(RefreshActionData actionData)
@@ -125,7 +125,6 @@ namespace Microsoft.Teams.Samples.UserSpecificViews.Cards
 
         private static AdaptiveCardTemplate GetCardTemplate(string templatePath)
         {
-            templatePath = string.Format(templatePath, AppDomain.CurrentDomain.BaseDirectory);
             return new AdaptiveCardTemplate(File.ReadAllText(templatePath));
         }
 


### PR DESCRIPTION
This PR addresses a file path compatibility issue in the [bot-adaptivecards-user-specific-views/csharp ](https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/main/samples/bot-adaptivecards-user-specific-views/csharp) project. Previously, the file paths were hardcoded with backslashes (`\`), which caused `FileNotFoundExceptions` on Unix-based systems like macOS or Linux, which use forward slashes (`/`) in file paths.

The fix involves using `Path.Combine` to create the file paths, which automatically uses the correct type of slash depending on the operating system. This ensures that the project works correctly regardless of the operating system.