### PR TITLE
Update to latest Nuget libs and address breaking changes in Graph client library

### DIFF
--- a/samples/bot-conversation-sso-quickstart/csharp_dotnetcore/BotConversationSsoQuickstart/BotConversationSsoQuickstart.csproj
+++ b/samples/bot-conversation-sso-quickstart/csharp_dotnetcore/BotConversationSsoQuickstart/BotConversationSsoQuickstart.csproj
@@ -1,21 +1,22 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   
   <PropertyGroup>
-	  <TargetFramework>net6.0</TargetFramework>
+	  <TargetFramework>net7.0</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="AdaptiveCards" Version="2.7.3" />
-	  <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.11" />
-	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.11" />
-	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.11" />
-	  <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.19.2" />
-	  <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.19.2" />
-	  <PackageReference Include="Microsoft.Bot.Schema" Version="4.19.2" />
-	  <PackageReference Include="Microsoft.Graph" Version="4.47.0" />
-	  <PackageReference Include="Microsoft.Graph.Core" Version="2.0.14" />
-	  <PackageReference Include="Microsoft.Identity.Web" Version="1.25.5" />
+	  <PackageReference Include="AdaptiveCards" Version="3.0.0" />
+	  <PackageReference Include="Microsoft.AspNetCore.Authentication.AzureAD.UI" Version="6.0.22" />
+	  <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="7.0.11" />
+	  <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="7.0.11" />
+	  <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.21.0" />
+	  <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.21.0" />
+	  <PackageReference Include="Microsoft.Bot.Schema" Version="4.21.0" />
+	  <PackageReference Include="Microsoft.Graph" Version="5.28.0" />
+	  <PackageReference Include="Microsoft.Graph.Core" Version="3.0.11" />
+	  <PackageReference Include="Microsoft.Identity.Web" Version="2.13.4" />
   </ItemGroup>
 
 </Project>
+


### PR DESCRIPTION
The grpah client library introduces breaking changes that prevent SimpleGraphClient from building.
This PR udpates the Nugets in the example, brings it to net7.0, and fixes SimpleGraphClient.

https://github.com/microsoftgraph/msgraph-sdk-dotnet/blob/feature/5.0/docs/upgrade-to-v5.md