### PR TITLE
fix: wrong app name and local debug fail

### DIFF
--- a/samples/bot-proactive-messaging-teamsfx/bot/package.json
+++ b/samples/bot-proactive-messaging-teamsfx/bot/package.json
@@ -22,6 +22,7 @@
     "botbuilder": "~4.15.0",
     "botbuilder-dialogs": "~4.5.0",
     "isomorphic-fetch": "^3.0.0",
+    "dotenv": "^16.3.1",
     "restify": "^10.0.0"
   },
   "devDependencies": {

--- a/samples/bot-proactive-messaging-teamsfx/package.json
+++ b/samples/bot-proactive-messaging-teamsfx/package.json
@@ -12,7 +12,6 @@
     "dependencies": {
         "botbuilder": "^4.18.0",
         "botbuilder-dialogs": "^4.18.0",
-        "dotenv": "^16.3.1",
         "restify": "^11.1.0"
     },
     "devDependencies": {

--- a/samples/bot-proactive-messaging-teamsfx/teamsapp.local.yml
+++ b/samples/bot-proactive-messaging-teamsfx/teamsapp.local.yml
@@ -19,7 +19,7 @@ provision:
 
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{CONFIG__MANIFEST__APPNAME__SHORT}} # Teams app name
+      name: proactive-messages-demo-${{TEAMSFX_ENV}} # Teams app name
     writeToEnvironmentFile:
       # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID

--- a/samples/bot-proactive-messaging-teamsfx/teamsapp.yml
+++ b/samples/bot-proactive-messaging-teamsfx/teamsapp.yml
@@ -22,7 +22,7 @@ provision:
       authorityHost: AAD_APP_OAUTH_AUTHORITY_HOST
   - uses: teamsApp/create # Creates a Teams app
     with:
-      name: ${{CONFIG__MANIFEST__APPNAME__SHORT}} # Teams app name
+      name: proactive-messages-demo-${{TEAMSFX_ENV}} # Teams app name
     writeToEnvironmentFile:
       # Write the information of created resources into environment file for the specified environment variable(s).
       teamsAppId: TEAMS_APP_ID
@@ -103,4 +103,3 @@ publish:
     writeToEnvironmentFile:
       # Write the information of created resources into environment file for the specified environment variable(s).
       publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
-projectId: 50e830d7-2c4b-4de9-8e7d-17e4100e43e1


### PR DESCRIPTION
Fix following issues:
1. app name in ttk notification window doesn't shown correctly
2. Local debug fail due to dotenv dependency