### PR TITLE
Demo-manifest path updated for both the sample nodejs and csharp

### DIFF
--- a/samples/bot-sequential-flow-adaptive-cards/csharp/README.md
+++ b/samples/bot-sequential-flow-adaptive-cards/csharp/README.md
@@ -23,7 +23,7 @@ This sample illustrates sequential workflow, user specific views and upto date a
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Sequential workflow adaptive cards:** [Manifest](/samples/bot-sequential-flow-adaptive-cards/csharp/demo-manifest/bot-adaptivecards-user-specific-views.zip)
+**Sequential workflow adaptive cards:** [Manifest](/samples/bot-sequential-flow-adaptive-cards/csharp/demo-manifest/bot-sequential-flow-adaptive-cards.zip)
 
 ## Prerequisites
 

--- a/samples/bot-sequential-flow-adaptive-cards/nodejs/Readme.md
+++ b/samples/bot-sequential-flow-adaptive-cards/nodejs/Readme.md
@@ -21,7 +21,7 @@ urlFragment: officedev-microsoft-teams-samples-bot-sequential-flow-adaptive-card
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Sequential workflow adaptive cards:** [Manifest](/samples/bot-sequential-flow-adaptive-cards/csharp/demo-manifest/bot-adaptivecards-user-specific-views.zip)
+**Sequential workflow adaptive cards:** [Manifest](/samples/bot-sequential-flow-adaptive-cards/csharp/demo-manifest/bot-sequential-flow-adaptive-cards.zip)
 
 This App talks about the Teams Bot User Specific Views and Sequential Workflows in adaptive card with Node JS
 


### PR DESCRIPTION
**Issue Link :** 
[Demo manifest not valid for Sequential workflow adaptive cards C# and Node sample · Issue #926 · OfficeDev/Microsoft-Teams-Samples (github.com)](https://github.com/OfficeDev/Microsoft-Teams-Samples/issues/926)