### PR TITLE
fix: change python to debugpy

### DIFF
--- a/samples/bot-conversation/python/.vscode/launch.json
+++ b/samples/bot-conversation/python/.vscode/launch.json
@@ -31,7 +31,7 @@
         },
         {
             "name": "Python: Run App Locally",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/app.py",
             "cwd": "${workspaceFolder}",

--- a/samples/msgext-search/python/.vscode/launch.json
+++ b/samples/msgext-search/python/.vscode/launch.json
@@ -31,7 +31,7 @@
         },
         {
             "name": "Python: Run App Locally",
-            "type": "python",
+            "type": "debugpy",
             "request": "launch",
             "program": "${workspaceFolder}/app.py",
             "cwd": "${workspaceFolder}",


### PR DESCRIPTION
Respect to new python extension in VSCode, replace "python" with "debugpy" when launch python. 