### PR TITLE
handleTeamsFileConsent method added in bot file upload sample nodejs

### DIFF
--- a/samples/bot-file-upload/nodejs/bots/teamsFileUploadBot.js
+++ b/samples/bot-file-upload/nodejs/bots/teamsFileUploadBot.js
@@ -131,6 +131,11 @@ class TeamsFileUploadBot extends TeamsActivityHandler {
             contentUrl: `data:image/png;base64,${ base64Image }`
         };
     }
+
+    async handleTeamsFileConsent(context,response){
+        console.log("handleTeamsFileConsent() method executed");
+        console.log(context,response);
+    }
 }
 
 module.exports.TeamsFileUploadBot = TeamsFileUploadBot;


### PR DESCRIPTION
Only one method we have implemented in JS sample and we able to get break point on this below method.
**handleTeamsFileConsent**

**Code Snippet :**
```
 async handleTeamsFileConsent(context,response){
        console.log("handleTeamsFileConsent() method executed");
        console.log(context,response);
    }
```
