### PR TITLE
File Upload Message Updated When Successfully File Uploaded

### DIFF
--- a/samples/app-region-selection/csharp/RegionSectionApp/Views/Home/Index.cshtml
+++ b/samples/app-region-selection/csharp/RegionSectionApp/Views/Home/Index.cshtml
@@ -20,15 +20,14 @@
     <p>
         <div>
             <label for="domainChoice">Select the data center Region you would like to set: </label>
-            @* Added defects to check automation flow *@ 
 
-            @* <select id="domainChoice" name="domainChoice">
+            <select id="domainChoice" name="domainChoice">
                 <option value="" selected="selected">(Select a region)</option>
                 @foreach (var item in Model.regionDomains)
                 {
                     <option value="@item.region">@(  item.country + " - " + item.region)</option>
                 }
-            </select> *@
+            </select>
         </div>
     </p>
 

--- a/samples/bot-file-upload/csharp/Bots/TeamsFileUploadBot.cs
+++ b/samples/bot-file-upload/csharp/Bots/TeamsFileUploadBot.cs
@@ -182,10 +182,6 @@ namespace Microsoft.BotBuilderSamples.Bots
                 ContentUrl = fileConsentCardResponse.UploadInfo.ContentUrl,
             };
 
-
-            // var reply = MessageFactory.Text($"<b>File uploaded.</b> Your file <b>{fileConsentCardResponse.UploadInfo.Name}</b> is ready to download");
-            // Added defects to check automation flow
-
             var reply = MessageFactory.Text($"<b>File uploaded.</b> Your file <b>{fileConsentCardResponse.UploadInfo.Name}</b> is ready to download");
             reply.TextFormat = "xml";
             reply.Attachments = new List<Attachment> { asAttachment };

--- a/samples/bot-file-upload/csharp/Bots/TeamsFileUploadBot.cs
+++ b/samples/bot-file-upload/csharp/Bots/TeamsFileUploadBot.cs
@@ -186,7 +186,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             // var reply = MessageFactory.Text($"<b>File uploaded.</b> Your file <b>{fileConsentCardResponse.UploadInfo.Name}</b> is ready to download");
             // Added defects to check automation flow
 
-            var reply = MessageFactory.Text($"<b>File uploaded Successfully.</b>");
+            var reply = MessageFactory.Text($"<b>File uploaded.</b> Your file <b>{fileConsentCardResponse.UploadInfo.Name}</b> is ready to download");
             reply.TextFormat = "xml";
             reply.Attachments = new List<Attachment> { asAttachment };
 

--- a/samples/bot-file-upload/csharp/Bots/TeamsFileUploadBot.cs
+++ b/samples/bot-file-upload/csharp/Bots/TeamsFileUploadBot.cs
@@ -186,7 +186,7 @@ namespace Microsoft.BotBuilderSamples.Bots
             // var reply = MessageFactory.Text($"<b>File uploaded.</b> Your file <b>{fileConsentCardResponse.UploadInfo.Name}</b> is ready to download");
             // Added defects to check automation flow
 
-            var reply = MessageFactory.Text($"<b>File upload failed.</b>");
+            var reply = MessageFactory.Text($"<b>File uploaded Successfully.</b>");
             reply.TextFormat = "xml";
             reply.Attachments = new List<Attachment> { asAttachment };
 


### PR DESCRIPTION
**File Upload Issue Link :** [CSharp bot-file-upload TeamsFileUploadBot.FileUploadCompletedAsync always sends an error message · Issue #1197 · OfficeDev/Microsoft-Teams-Samples (github.com)](https://github.com/OfficeDev/Microsoft-Teams-Samples/issues/1197)

**File is uploading Successfully but message was wrongly displayed previously.**
<img width="957" alt="image" src="https://github.com/OfficeDev/Microsoft-Teams-Samples/assets/109147706/24a170a6-b8d8-43ba-abc0-9507a486682f">

**Now corrected to actual message when successful uploaded**
<img width="955" alt="image" src="https://github.com/OfficeDev/Microsoft-Teams-Samples/assets/109147706/d3c43146-6794-43bf-a127-403dfb002d88">

