### PR TITLE
Meeting Live Caption Nodejs Fixes for Disable Save Button

### DIFF
--- a/samples/meetings-live-caption/nodejs/views/configure.ejs
+++ b/samples/meetings-live-caption/nodejs/views/configure.ejs
@@ -2,6 +2,10 @@
 <html lang="en">
 
 <head>
+    <script src="https://res.cdn.office.net/teams-js/2.22.0/js/MicrosoftTeams.min.js"
+        integrity="sha384-WSG/sWulIv7rel5TnFlH8JTpxl2OxzZh9Lux2mIzBFiTRLFvMBeFv9VURu/3vQdx"
+        crossorigin="anonymous"></script>
+    </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
@@ -15,14 +19,8 @@
             padding: 0.5rem;
         }
     </style>
-        <script src="../jquery.min.js"></script>
-    <script
-    src="..//MicrosoftTeams.min.js"
-    integrity="sha384-h+MoYshcGDPMLlXjHLt2dSgsgYyWQ+yHd4Ob13htDsu8trGPea8Vooa8+tLtRzU7"
-    crossorigin="anonymous"
-  ></script>
-    <script type="text/javascript"> 
-    $(document).ready(function () {
+
+    <script>
         microsoftTeams.app.initialize().then(() => {
             microsoftTeams.pages.config.registerOnSaveHandler((saveEvent) => {
                 var myHeaders = new Headers();
@@ -53,7 +51,7 @@
                     .catch(error => saveEvent.notifyFailure(error));
             });
         });
-    });
+
         function onCARTInputChange(url) {
             var errorSpan = document.getElementById("error_messsage");
 

--- a/samples/meetings-live-caption/nodejs/views/index.ejs
+++ b/samples/meetings-live-caption/nodejs/views/index.ejs
@@ -2,12 +2,15 @@
 <html lang="en">
 
 <head>
+    <script src="https://res.cdn.office.net/teams-js/2.22.0/js/MicrosoftTeams.min.js"
+        integrity="sha384-WSG/sWulIv7rel5TnFlH8JTpxl2OxzZh9Lux2mIzBFiTRLFvMBeFv9VURu/3vQdx"
+        crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <!-- <meta http-equiv="Content-Security-Policy" content="default-src *; style-src 'self' 'unsafe-inline' http://localhost:3978; script-src 'self' 'unsafe-inline' 'unsafe-eval'"> -->
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline';" />
 
-     
+
     <title>Meeting Live Caption</title>
     <link rel="stylesheet" href="../style.css">
     <style>
@@ -16,7 +19,6 @@
         }
 
         .container {
-            color: white;
             padding: 0.5rem;
         }
 
@@ -34,14 +36,7 @@
             background-color: #7A80EB;
         }
     </style>
-          <script src="../jquery.min.js"></script>
-          <script
-          src="..//MicrosoftTeams.min.js"
-          integrity="sha384-h+MoYshcGDPMLlXjHLt2dSgsgYyWQ+yHd4Ob13htDsu8trGPea8Vooa8+tLtRzU7"
-          crossorigin="anonymous"
-        ></script>
-    <script type="text/javascript"> 
-        $(document).ready(function () {
+    <script>
         microsoftTeams.app.initialize().then(() => {
             microsoftTeams.app.getContext().then((context) => {
                 var infoDiv = document.getElementById("show-info");
@@ -56,7 +51,7 @@
                 }
             });
         });
-    });
+
         function onSubmitCaption() {
             var captionInput = document.getElementById("caption");
             document.getElementById("loader").hidden = false;
@@ -109,6 +104,7 @@
             </div>
         </form>
     </div>
+
 </body>
 
 </html>


### PR DESCRIPTION
Meeting Live Caption : https://github.com/OfficeDev/Microsoft-Teams-Samples/tree/fb1d867d5d8499a7a92b8e38e5eca04e26eb7327/samples/meetings-live-caption/nodejs

**Configurable tab with save button enabled**
<img width="930" alt="Config" src="https://github.com/OfficeDev/Microsoft-Teams-Samples/assets/109147706/95fe4511-654c-41f6-85c1-75144cb35dd9">
**Side-panel with live caption** 
<img width="959" alt="Image 2" src="https://github.com/OfficeDev/Microsoft-Teams-Samples/assets/109147706/10c1a3a0-0e7e-4dc0-b508-06529ecbd3b8">


