### PR TITLE
Updated deep-link creation logic in tab-request-approval.

### DIFF
--- a/samples/tab-request-approval/csharp/TabRequestApproval/Controllers/HomeController.cs
+++ b/samples/tab-request-approval/csharp/TabRequestApproval/Controllers/HomeController.cs
@@ -125,17 +125,17 @@ namespace TabRequestApproval.Controllers
                     // Retrieve installed apps for the user from Microsoft Graph API
                     var installedApps = await graphClient.Users[user.Id].Teamwork.InstalledApps
                                        .Request()
-                                       .Expand("teamsApp")
+                                       .Expand("teamsAppDefinition")
                                        .GetAsync();
 
                     // Filter installed apps to find the one with DisplayName "Tab Request Approval"
-                    var installationId = installedApps.Where(id => id.TeamsApp.DisplayName == "Tab Request Approval").Select(x => x.TeamsApp.Id);
+                    var installationId = installedApps.Where(id => id.TeamsAppDefinition.DisplayName == "Tab Request Approval").Select(x => x.TeamsAppDefinition.Id);
 
                     // Check if there is at least one matching installationId
                     if (installationId.Any())
                     {
                         // Construct URL for the Teams entity
-                        var url = "https://teams.microsoft.com/l/entity/" + installationId.ToList()[0] + "/request?context={\"subEntityId\":\"" + taskInfo.taskId + "\"}";
+                        var url = "https://teams.microsoft.com/l/entity/" + _configuration["AzureAd:MicrosoftAppId"] + "/request?context={\"subEntityId\":\"" + taskInfo.taskId + "\"}";
 
                         // Create a TeamworkActivityTopic for the notification
                         var topic = new TeamworkActivityTopic


### PR DESCRIPTION
Hi @VaraPrasad-MSFT @Pawank-MSFT 
I figured out that in tab-request-approval app, the logic that creates a deep link for activity notification, was using "installation-id". But as per the Microsoft documentation, we need to use the app-id in the deep-link.

Please refer to this article by the Microsoft:
https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/deep-link-application?tabs=teamsjs-v2#configure-deep-link-to-browse-within-your-app-manually

After this change I am able to view the request details when I click on the activity notification in Teams.

The link generated by the old logic:
https://teams.microsoft.com/l/entity/**NWNjMTM0YzYtMjZjYy00MTY3LWI2NmItM2MwOWFhMzUwYjFlIyMxLjAuMCMjUHVibGlzaGVk**/request?context={"subEntityId":"8afee96e-b5cf-4afe-9534-fbf1f7fc2dbf"}

The link generated by the new logic:
https://teams.microsoft.com/l/entity/**4d2f0656-0c42-4c76-8f18-3796f4c37f0f**/request?context={"subEntityId":"21281529-4ce7-41f4-a906-8d87e40b3632"}

![tab-request-approval-notification](https://github.com/user-attachments/assets/57fc6159-0c8f-439c-b6ae-91ee0ff4f781)

![MS Teams Article](https://github.com/user-attachments/assets/0e95df07-a8ca-46a7-9f94-7f849ef5f68e)
