### PR TITLE
Use of latest Microsoft.Graph nuget package

### DIFF
--- a/samples/tab-request-approval/csharp/TabRequestApproval/Controllers/HomeController.cs
+++ b/samples/tab-request-approval/csharp/TabRequestApproval/Controllers/HomeController.cs
@@ -127,7 +127,7 @@ namespace TabRequestApproval.Controllers
                                        });
 
                     // Filter installed apps to find the one with DisplayName "Tab Request Approval"
-                    var installationId = installedApps.Value.Where(id => id.TeamsAppDefinition.DisplayName == "Tab Request Approval").Select(x => x.TeamsAppDefinition.Id);
+                    var installationId = installedApps.Value.Where(id => id.TeamsAppDefinition.DisplayName == "Tab Request Approval").Select(x => x.TeamsAppDefinition.TeamsAppId);
 
                     // Check if there is at least one matching installationId
                     if (installationId.Any())

--- a/samples/tab-request-approval/csharp/TabRequestApproval/Controllers/HomeController.cs
+++ b/samples/tab-request-approval/csharp/TabRequestApproval/Controllers/HomeController.cs
@@ -2,11 +2,10 @@
 // Copyright (c) Microsoft. All Rights Reserved.
 // </copyright>
 
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Graph;
+using Microsoft.Graph.Models;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -118,53 +117,45 @@ namespace TabRequestApproval.Controllers
                     var graphClient = SimpleGraphClient.GetGraphClient(taskInfo.access_token);
 
                     // Retrieve user information from Microsoft Graph API
-                    var user = await graphClient.Users[taskInfo.personaName]
-                              .Request()
-                              .GetAsync();
+                    var user = await graphClient.Users[taskInfo.personaName].GetAsync();
 
                     // Retrieve installed apps for the user from Microsoft Graph API
-                    var installedApps = await graphClient.Users[user.Id].Teamwork.InstalledApps
-                                       .Request()
-                                       .Expand("teamsApp")
-                                       .GetAsync();
+                    var installedApps = await graphClient.Users[user.UserPrincipalName].Teamwork.InstalledApps
+                                       .GetAsync((requestConfiguration) =>
+                                       {
+                                           requestConfiguration.QueryParameters.Expand = new string[] { "teamsAppDefinition" };
+                                       });
 
                     // Filter installed apps to find the one with DisplayName "Tab Request Approval"
-                    var installationId = installedApps.Where(id => id.TeamsApp.DisplayName == "Tab Request Approval").Select(x => x.TeamsApp.Id);
+                    var installationId = installedApps.Value.Where(id => id.TeamsAppDefinition.DisplayName == "Tab Request Approval").Select(x => x.TeamsAppDefinition.Id);
 
                     // Check if there is at least one matching installationId
                     if (installationId.Any())
                     {
-                        // Construct URL for the Teams entity
-                        var url = "https://teams.microsoft.com/l/entity/" + installationId.ToList()[0] + "/request?context={\"subEntityId\":\"" + taskInfo.taskId + "\"}";
-
-                        // Create a TeamworkActivityTopic for the notification
-                        var topic = new TeamworkActivityTopic
+                        var requestBody = new Microsoft.Graph.Users.Item.Teamwork.SendActivityNotification.SendActivityNotificationPostRequestBody
                         {
-                            Source = TeamworkActivityTopicSource.Text,
-                            Value = $"{taskInfo.title}",
-                            WebUrl = url
-                        };
-
-                        // Create preview text for the notification
-                        var previewText = new ItemBody
-                        {
-                            Content = $"Request By: {taskInfo.userName}"
-                        };
-
-                        // Create template parameters for the notification
-                        var templateParameters = new List<Microsoft.Graph.KeyValuePair>()
-                        {
-                            new Microsoft.Graph.KeyValuePair
+                            Topic = new TeamworkActivityTopic
                             {
-                                Name = "approvalTaskId",
-                                Value = taskInfo.title
-                            }
+                                Source = TeamworkActivityTopicSource.Text,
+                                Value = $"{taskInfo.title}",
+                                WebUrl = "https://teams.microsoft.com/l/entity/" + _configuration["AzureAd:MicrosoftAppId"] + "/request?context={\"subEntityId\":\"" + taskInfo.taskId + "\"}"
+                            },
+                            ActivityType = "approvalRequired",
+                            PreviewText = new ItemBody
+                            {
+                                Content = $"Request By: {taskInfo.userName}"
+                            },
+                            TemplateParameters = new List<Microsoft.Graph.Models.KeyValuePair>
+                            {
+                                new Microsoft.Graph.Models.KeyValuePair
+                                {
+                                    Name = "approvalTaskId",
+                                    Value = taskInfo.title
+                                },
+                            },
                         };
-                        // Send the activity notification using Microsoft Graph API
-                        await graphClient.Users[user.Id].Teamwork
-                            .SendActivityNotification(topic, "approvalRequired", null, previewText, templateParameters)
-                            .Request()
-                            .PostAsync();
+
+                        await graphClient.Users[user.Id].Teamwork.SendActivityNotification.PostAsync(requestBody);
                     }
                 }
             }

--- a/samples/tab-request-approval/csharp/TabRequestApproval/SimpleGraphClient.cs
+++ b/samples/tab-request-approval/csharp/TabRequestApproval/SimpleGraphClient.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Net.Http.Headers;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Graph;
 using Microsoft.Identity.Client;
+using Microsoft.Kiota.Abstractions.Authentication;
 
 namespace TabRequestApproval
 {
@@ -10,17 +13,23 @@ namespace TabRequestApproval
     {
         public static GraphServiceClient GetGraphClient(string accessToken)
         {
-            var graphClient = new GraphServiceClient(new DelegateAuthenticationProvider((requestMessage) =>
-            {
-                requestMessage.Headers.Authorization = new AuthenticationHeaderValue("bearer", accessToken);
-
-                requestMessage.Headers.Add("Prefer", "outlook.timezone=\"" + TimeZoneInfo.Local.Id + "\"");
-
-                return Task.CompletedTask;
-            }));
-
-            return graphClient;
+            TokenProvider provider = new TokenProvider();
+            provider.token = accessToken;
+            var authenticationProvider = new BaseBearerTokenAuthenticationProvider(provider);
+            var graphServiceClient = new GraphServiceClient(authenticationProvider);
+            return graphServiceClient;
         }
 
+    }
+
+    public class TokenProvider : IAccessTokenProvider
+    {
+        public string token { get; set; }
+        public AllowedHostsValidator AllowedHostsValidator => throw new NotImplementedException();
+
+        public Task<string> GetAuthorizationTokenAsync(Uri uri, Dictionary<string, object>? additionalAuthenticationContext = null, CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(token);
+        }
     }
 }

--- a/samples/tab-request-approval/csharp/TabRequestApproval/TabRequestApproval.csproj
+++ b/samples/tab-request-approval/csharp/TabRequestApproval/TabRequestApproval.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.11" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.18.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Graph" Version="5.58.0" />
     <PackageReference Include="Microsoft.Graph.Auth" Version="1.0.0-preview.6" />
-    <PackageReference Include="Microsoft.Graph.Beta" Version="0.35.0-preview" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.48.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.10" />
   </ItemGroup>


### PR DESCRIPTION
****This commit provides following updates:
1. Updated the Microsoft.Graph nuget package from the preview (beta) version to the latest version (5.58.0).
2. As DelegateAuthenticationProvider is deprecated, replaced it with the use of IAuthenticationProvider.

**One can refer to this sample app, if he/she wants to use the latest Graph API nuget package.**

![tab-request-approval-notification-new](https://github.com/user-attachments/assets/0056064e-7f5f-49e9-9477-9c94a15f050c)
