### PR TITLE
fix: add sampleTag and remove projectId for telemetry tracking

### DIFF
--- a/samples/graph-rsc-helper/nodeJs/m365agents.yml
+++ b/samples/graph-rsc-helper/nodeJs/m365agents.yml
@@ -7,4 +7,3 @@ additionalMetadata:
   sampleTag: Microsoft-Teams-Samples:graph-rsc-nodeJs
 
 environmentFolderPath: ./env
-projectId: 722ec657-0d89-4adb-8dc4-a05f8e8d5283

--- a/samples/msgext-link-unfurling-reddit/nodejs/m365agents.yml
+++ b/samples/msgext-link-unfurling-reddit/nodejs/m365agents.yml
@@ -124,4 +124,6 @@ publish:
     # the specified environment variable(s).
     writeToEnvironmentFile:
       publishedAppId: TEAMS_APP_PUBLISHED_APP_ID
-projectId: 08f760f9-4a79-42e2-a731-8e11df80ab4c
+
+additionalMetadata:
+  sampleTag: Microsoft-Teams-Samples:reddit-link-unfurling


### PR DESCRIPTION
## Summary

This PR fixes telemetry tracking issues for two samples by:

1. **reddit-link-unfurling** (msgext-link-unfurling-reddit/nodejs)
   - Added `sampleTag: Microsoft-Teams-Samples:reddit-link-unfurling`
   - Removed `projectId`

2. **graph-rsc-helper** (graph-rsc-helper/nodeJs)
   - Removed `projectId` (sampleTag already exists)

## Why is this needed?

The `sampleTag` in `m365agents.yml` is required for M365 Agents Toolkit to track sample usage telemetry. Without it, usage data cannot be properly attributed to these samples.

The `projectId` should be removed as it's meant to be generated per-user when they create a project from the sample, not hardcoded in the template.

## Validation

Both samples have been validated using the TeamsFx Sample Validator tool.