### PR TITLE
fix: Update Python version for msgext-search sample to 3.13.x

### DIFF
--- a/.github/workflows/build-complete-samples.yml
+++ b/.github/workflows/build-complete-samples.yml
@@ -1220,7 +1220,7 @@ jobs:
 
             - project_path: 'samples/msgext-search/python'
               name: 'msgext-search'
-              version: '3.10.x'
+              version: '3.13.x'
 
             - project_path: 'samples/msgext-action/python'
               name: 'msgext-action'

--- a/samples/msgext-search/python/README.md
+++ b/samples/msgext-search/python/README.md
@@ -37,7 +37,7 @@ Please find below demo manifest which is deployed on Microsoft Azure and you can
 ## Prerequisites
 
 - Microsoft Teams is installed and you have an account
-- [Python SDK](https://www.python.org/downloads/) version 3.7
+- [Python SDK](https://www.python.org/downloads/) version 3.13
 - [dev tunnel](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows) or [ngrok](https://ngrok.com/) latest version or equivalent tunnelling solution
 
 


### PR DESCRIPTION
The microsoft-teams-api>=2.0.0a8 package requires Python >=3.12, but the CI pipeline was configured to use Python 3.10.x, causing the build to fail. Updated Python version from 3.10.x to 3.13.x in both the CI workflow and README.