### PR TITLE
Rethrow to preserve stack details (CA2200)

### DIFF
--- a/samples/app-installation-using-qr-code/csharp/QRAppInstallation/SimpleGraphClient.cs
+++ b/samples/app-installation-using-qr-code/csharp/QRAppInstallation/SimpleGraphClient.cs
@@ -47,7 +47,7 @@ namespace QRAppInstallation
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/bot-calling-meeting/csharp/Source/CallingBotSample/Services/MicrosoftGraph/CallService.cs
+++ b/samples/bot-calling-meeting/csharp/Source/CallingBotSample/Services/MicrosoftGraph/CallService.cs
@@ -303,7 +303,7 @@ namespace CallingBotSample.Services.MicrosoftGraph
                 if (ex.StatusCode != HttpStatusCode.NotFound)
                 {
                     // If it's not a NotFound error please ignore
-                    throw ex;
+                    throw;
                 }
 
                 return "That action failed. Unable to find call";

--- a/samples/bot-join-team-using-qr-code/csharp/JoinTeamByQR/helper/JoinTeamHelper.cs
+++ b/samples/bot-join-team-using-qr-code/csharp/JoinTeamByQR/helper/JoinTeamHelper.cs
@@ -28,7 +28,7 @@ namespace JoinTeamByQR.helper
             }
             catch (ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/bot-sharepoint-file-viewer/csharp/BotWithSharePointFileViewer/helper/SharePointFileHelper.cs
+++ b/samples/bot-sharepoint-file-viewer/csharp/BotWithSharePointFileViewer/helper/SharePointFileHelper.cs
@@ -29,7 +29,7 @@ namespace BotWithSharePointFileViewer.helper
             }
             catch (ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/graph-proactive-installation/csharp/ProactiveAppInstallation/Models/ProactiveAppIntallationHelper.cs
+++ b/samples/graph-proactive-installation/csharp/ProactiveAppInstallation/Models/ProactiveAppIntallationHelper.cs
@@ -59,8 +59,8 @@ namespace ProactiveBot.Bots
                 else
                 {
                     throw;
-                }
-            }
+            	}
+       		}
         }
 
         public async Task TriggerConversationUpdate(string Userid, string MicrosoftTenantId, string MicrosoftAppId, string MicrosoftAppPassword, string MicrosoftTeamAppid)
@@ -85,7 +85,7 @@ namespace ProactiveBot.Bots
             }
             catch (Microsoft.Graph.ServiceException ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/incoming-webhook/csharp/IncomingWebhook/Controllers/CardController.cs
+++ b/samples/incoming-webhook/csharp/IncomingWebhook/Controllers/CardController.cs
@@ -33,7 +33,7 @@ namespace IncomingWebhook.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -59,7 +59,7 @@ namespace IncomingWebhook.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/CandidateController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/CandidateController.cs
@@ -41,7 +41,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -66,7 +66,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/FeedbackController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/FeedbackController.cs
@@ -36,7 +36,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotesController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotesController.cs
@@ -55,7 +55,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -75,7 +75,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotifyController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/NotifyController.cs
@@ -107,7 +107,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/QuestionController.cs
+++ b/samples/meeting-recruitment-app/csharp/MeetingApp/Controllers/QuestionController.cs
@@ -39,7 +39,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -60,7 +60,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -81,7 +81,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -101,7 +101,7 @@ namespace MeetingApp.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/meetings-live-code-interview/csharp/MeetingLiveCoding/Controllers/MeetingController.cs
+++ b/samples/meetings-live-code-interview/csharp/MeetingLiveCoding/Controllers/MeetingController.cs
@@ -62,7 +62,7 @@ namespace MeetingLiveCoding.Controllers
                 }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -112,7 +112,7 @@ namespace MeetingLiveCoding.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
     }

--- a/samples/tab-meeting-auto-recording/csharp/MeetingAutoRecording/Controllers/AuthController.cs
+++ b/samples/tab-meeting-auto-recording/csharp/MeetingAutoRecording/Controllers/AuthController.cs
@@ -451,7 +451,7 @@ namespace MeetingAutoRecording.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -528,7 +528,7 @@ namespace MeetingAutoRecording.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -603,7 +603,7 @@ namespace MeetingAutoRecording.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 
@@ -630,7 +630,7 @@ namespace MeetingAutoRecording.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 

--- a/samples/tab-meeting-transcript-recording/csharp/MeetingTranscriptRecording/Controllers/AuthController.cs
+++ b/samples/tab-meeting-transcript-recording/csharp/MeetingTranscriptRecording/Controllers/AuthController.cs
@@ -375,7 +375,7 @@ namespace MeetingTranscriptRecording.Controllers
             }
             catch (Exception ex)
             {
-                throw ex;
+                throw;
             }
         }
 


### PR DESCRIPTION
Stack trace is lost with the current samples.

Arguably these exceptions could be left uncaught to bubble up, but I'm assuming that they're in to make debugging and setting breakpoints easier so I've not removed them

(originally filed as #335 but have rebased since then)