### PR TITLE
Fix broken demo-manifest links in TeamsJS sample READMEs

### DIFF
--- a/samples/TeamsJS/app-sso/csharp/README.md
+++ b/samples/TeamsJS/app-sso/csharp/README.md
@@ -51,7 +51,7 @@ The sample uses the bot authentication capabilities in [Azure Bot Service](https
  ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**App SSO:** [Manifest](/samples/app-sso/csharp/demo-manifest/App-SSO.zip)
+**App SSO:** [Manifest](/samples/TeamsJS/app-sso/csharp/demo-manifest/App-SSO.zip)
 
 ## Prerequisites
 
@@ -85,7 +85,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 ### 1. Setup for Bot SSO
 - Setup for Bot SSO
-Refer to [Bot SSO Setup document](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/bot-conversation-sso-quickstart/BotSSOSetup.md).
+Refer to [Bot SSO Setup document](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/bot-conversation-sso-quickstart/BotSSOSetup.md).
 
 Make sure your Application ID Url under Expose and API section is in below format. The above sso document uses only bot-sso. This sample uses both tab + bot sso so replace the url format.
  `api://<your_tunnel_domain>/botid-<<YOUR-MICROSOFT-APP-ID>>`
@@ -211,7 +211,7 @@ Make sure your Application ID Url under Expose and API section is in below forma
 
 **Note**: This `manifest.json` specified that the bot will be installed in a "personal" scope only. Please refer to Teams documentation for more details. 
   
-- If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/app-sso/csharp/App%20SSO%20Sample/AdapterWithErrorHandler.cs#L255) line and put your debugger for local debug.
+- If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/app-sso/csharp/App%20SSO%20Sample/AdapterWithErrorHandler.cs#L255) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -334,4 +334,4 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
 - [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/microsoftteams/platform/m365-apps/overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/app-sso-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/app-sso-csharp" />

--- a/samples/TeamsJS/app-sso/nodejs/README.md
+++ b/samples/TeamsJS/app-sso/nodejs/README.md
@@ -46,7 +46,7 @@ The sample uses the bot authentication capabilities in [Azure Bot Service](https
  ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**App SSO:** [Manifest](/samples/app-sso/csharp/demo-manifest/App-SSO.zip)
+**App SSO:** [Manifest](/samples/TeamsJS/app-sso/csharp/demo-manifest/App-SSO.zip)
 
 ## Prerequisites
 
@@ -69,7 +69,7 @@ If you use Ngrok, make sure you've downloaded and installed Ngrok on your local 
 
 ### 1. Setup for Bot
 - Setup for Bot SSO
-Refer to [Bot SSO Setup document](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/bot-conversation-sso-quickstart/BotSSOSetup.md).
+Refer to [Bot SSO Setup document](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/bot-conversation-sso-quickstart/BotSSOSetup.md).
 
 - Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
 
@@ -192,7 +192,7 @@ Refer to [Bot SSO Setup document](https://github.com/OfficeDev/Microsoft-Teams-S
 
 **Note**: This `manifest.json` specified that the bot will be installed in a "personal" scope only. Please refer to Teams documentation for more details.
 
-- If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/app-sso/nodejs/server/api/botController.js#L32) line and put your debugger for local debug.
+- If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/app-sso/nodejs/server/api/botController.js#L32) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -316,4 +316,4 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/app-sso-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/app-sso-nodejs" />

--- a/samples/TeamsJS/graph-app-installation-lifecycle/csharp/README.md
+++ b/samples/TeamsJS/graph-app-installation-lifecycle/csharp/README.md
@@ -28,7 +28,7 @@ This sample app demonstrates the installation lifecycle for Teams [Apps](https:/
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**App Installation:** [Manifest](/samples/graph-app-installation-lifecycle/csharp/demo-manifest/graph-app-installation-lifecycle.zip)
+**App Installation:** [Manifest](/samples/TeamsJS/graph-app-installation-lifecycle/csharp/demo-manifest/graph-app-installation-lifecycle.zip)
 
 ## Prerequisites
 
@@ -136,7 +136,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 - [Upload app manifest file](https://docs.microsoft.com/microsoftteams/platform/concepts/deploy-and-publish/apps-upload#load-your-package-into-teams) (zip file) to your team
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/graph-appcatalog-lifecycle/nodejs/index.js#L45) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/graph-appcatalog-lifecycle/nodejs/index.js#L45) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -169,4 +169,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/graph-app-installation-lifecycle-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/graph-app-installation-lifecycle-csharp" />

--- a/samples/TeamsJS/graph-app-installation-lifecycle/nodejs/Readme.md
+++ b/samples/TeamsJS/graph-app-installation-lifecycle/nodejs/Readme.md
@@ -27,7 +27,7 @@ This sample app demonstrates the installation lifecycle for Teams [Apps](https:/
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**App Installation:** [Manifest](/samples/graph-app-installation-lifecycle/csharp/demo-manifest/graph-app-installation-lifecycle.zip)
+**App Installation:** [Manifest](/samples/TeamsJS/graph-app-installation-lifecycle/csharp/demo-manifest/graph-app-installation-lifecycle.zip)
 
 ## Prerequisites
 - Microsoft Teams is installed and you have an account (not a guest account)
@@ -150,4 +150,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/graph-app-installation-lifecycle-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/graph-app-installation-lifecycle-nodejs" />

--- a/samples/TeamsJS/graph-channel-lifecycle/csharp/README.md
+++ b/samples/TeamsJS/graph-channel-lifecycle/csharp/README.md
@@ -29,7 +29,7 @@ This sample application illustrates how to effectively manage the lifecycle of c
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Channel life cycle:** [Manifest](/samples/graph-channel-lifecycle/csharp/demo-manifest/graph-channel-lifecycle.zip)
+**Channel life cycle:** [Manifest](/samples/TeamsJS/graph-channel-lifecycle/csharp/demo-manifest/graph-channel-lifecycle.zip)
 
 ## Prerequisites
 - [.NET Core SDK](https://dotnet.microsoft.com/download) version 6.0
@@ -160,4 +160,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/graph-channel-lifecycle-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/graph-channel-lifecycle-csharp" />

--- a/samples/TeamsJS/graph-channel-lifecycle/nodejs/Readme.md
+++ b/samples/TeamsJS/graph-channel-lifecycle/nodejs/Readme.md
@@ -29,7 +29,7 @@ This sample application illustrates the complete lifecycle of channels in Micros
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Channel life cycle:** [Manifest](/samples/graph-channel-lifecycle/csharp/demo-manifest/graph-channel-lifecycle.zip)
+**Channel life cycle:** [Manifest](/samples/TeamsJS/graph-channel-lifecycle/csharp/demo-manifest/graph-channel-lifecycle.zip)
 
 
 ## Prerequisites
@@ -138,4 +138,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/graph-channel-lifecycle-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/graph-channel-lifecycle-nodejs" />

--- a/samples/TeamsJS/graph-rsc/csharp/README.md
+++ b/samples/TeamsJS/graph-rsc/csharp/README.md
@@ -28,7 +28,7 @@ This sample application showcases how to implement Resource Specific Consent (RS
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**RSC with Graph API:** [Manifest](/samples/graph-rsc/csharp/demo-manifest/graph-rsc.zip)
+**RSC with Graph API:** [Manifest](/samples/TeamsJS/graph-rsc/csharp/demo-manifest/graph-rsc.zip)
 
 ## Prerequisites
 
@@ -144,4 +144,4 @@ The simplest way to run this sample in Teams is to use Teams Toolkit for Visual 
 - [Graph RSC](https://learn.microsoft.com/microsoftteams/platform/graph-api/rsc/resource-specific-consent)
 - [Upload app manifest file](https://docs.microsoft.com/microsoftteams/platform/concepts/deploy-and-publish/apps-upload#load-your-package-into-teams) (zip file) to your team.
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/graph-rsc-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/graph-rsc-csharp" />

--- a/samples/TeamsJS/graph-rsc/nodeJs/Readme.md
+++ b/samples/TeamsJS/graph-rsc/nodeJs/Readme.md
@@ -28,7 +28,7 @@ This sample application illustrates how to utilize [Resource Specific Consent](h
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**RSC with Graph API:** [Manifest](/samples/graph-rsc/csharp/demo-manifest/graph-rsc.zip)
+**RSC with Graph API:** [Manifest](/samples/TeamsJS/graph-rsc/csharp/demo-manifest/graph-rsc.zip)
 
 ## Prerequisites
 
@@ -141,4 +141,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Upload app manifest file](https://docs.microsoft.com//microsoftteams/platform/concepts/deploy-and-publish/apps-upload#load-your-package-into-teams) (zip file) to your team.
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/graph-rsc-nodeJs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/graph-rsc-nodeJs" />

--- a/samples/TeamsJS/meeting-recruitment-app/csharp/README.md
+++ b/samples/TeamsJS/meeting-recruitment-app/csharp/README.md
@@ -32,7 +32,7 @@ It has meeting details and in-meeting app that helps in the interview process.
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Recruitment App Sample:** [Manifest](/samples/meeting-recruitment-app/csharp/demo-manifest/Meeting-Recruitment-App.zip)
+**Recruitment App Sample:** [Manifest](/samples/TeamsJS/meeting-recruitment-app/csharp/demo-manifest/Meeting-Recruitment-App.zip)
 
 ## Prerequisites
 
@@ -163,7 +163,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
    - Go to your project directory, the ./appPackage folder, select the zip folder, and choose Open.
    - Select Add in the pop-up dialog box. Your app is uploaded to Teams.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meeting-recruitment-app/csharp/MeetingApp/AdapterWithErrorHandler.cs#L25) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meeting-recruitment-app/csharp/MeetingApp/AdapterWithErrorHandler.cs#L25) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -236,4 +236,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Meeting apps APIs](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet)
 - [Install the App in Teams Meeting](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/teams-apps-in-meetings?view=msteams-client-js-latest#meeting-lifecycle-scenarios)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meeting-recruitment-app-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meeting-recruitment-app-csharp" />

--- a/samples/TeamsJS/meeting-recruitment-app/nodejs/Readme.md
+++ b/samples/TeamsJS/meeting-recruitment-app/nodejs/Readme.md
@@ -31,7 +31,7 @@ This sample app demonstrates how to enhance recruitment meetings in Microsoft Te
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Recruitment App Sample:** [Manifest](/samples/meeting-recruitment-app/csharp/demo-manifest/Meeting-Recruitment-App.zip)
+**Recruitment App Sample:** [Manifest](/samples/TeamsJS/meeting-recruitment-app/csharp/demo-manifest/Meeting-Recruitment-App.zip)
 
 ## Prerequisites
 
@@ -142,7 +142,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
    - Go to your project directory, the ./appManifest folder, select the zip folder, and choose Open.
    - Select Add in the pop-up dialog box. **Your app is uploaded to Teams**.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meeting-recruitment-app/nodejs/api/server/index.js#L55) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meeting-recruitment-app/nodejs/api/server/index.js#L55) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -225,4 +225,4 @@ Deploy your project to Azure by following these steps:
 - [Meeting apps APIs](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet)
 - [Install the App in Teams Meeting](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/teams-apps-in-meetings?view=msteams-client-js-latest#meeting-lifecycle-scenarios)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meeting-recruitment-app-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meeting-recruitment-app-nodejs" />

--- a/samples/TeamsJS/meeting-tabs/csharp/README.md
+++ b/samples/TeamsJS/meeting-tabs/csharp/README.md
@@ -33,7 +33,7 @@ This sample showcases muting/unmuting Teams meeting audio directly from the side
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meeting-Tabs:** [Manifest](/samples/meeting-tabs/csharp/demo-manifest/meeting-tabs.zip)
+**Meeting-Tabs:** [Manifest](/samples/TeamsJS/meeting-tabs/csharp/demo-manifest/meeting-tabs.zip)
 
 ## Prerequisites
 
@@ -196,4 +196,4 @@ Toggle button to Unmute state it will unmute client audio.
 - [Handle theme change](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/access-teams-context?tabs=Json-v2%2Cteamsjs-v2%2Cdefault#handle-theme-change)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meeting-tabs-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meeting-tabs-csharp" />

--- a/samples/TeamsJS/meeting-tabs/nodejs/Readme.md
+++ b/samples/TeamsJS/meeting-tabs/nodejs/Readme.md
@@ -32,7 +32,7 @@ This sample provides an interactive demonstration of a Teams meeting side panel 
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meeting-Tabs:** [Manifest](/samples/meeting-tabs/nodejs/demo-manifest/meeting-tabs.zip)
+**Meeting-Tabs:** [Manifest](/samples/TeamsJS/meeting-tabs/nodejs/demo-manifest/meeting-tabs.zip)
 
 ## Prerequisites
 
@@ -179,4 +179,4 @@ Toggle button to Unmute state it will unmute client audio.
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meeting-tabs-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meeting-tabs-nodejs" />

--- a/samples/TeamsJS/meeting-tabs/python/README.md
+++ b/samples/TeamsJS/meeting-tabs/python/README.md
@@ -32,7 +32,7 @@ This sample provides an interactive demonstration of a Teams meeting side panel 
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meeting-Tabs:** [Manifest](/samples/meeting-tabs/python/demo-manifest/meeting-tabs.zip)
+**Meeting-Tabs:** [Manifest](/samples/TeamsJS/meeting-tabs/python/demo-manifest/meeting-tabs.zip)
 
 ## Prerequisites
 
@@ -192,4 +192,4 @@ Toggle button to Unmute state it will unmute client audio.
 - [Generate meeting side panel](https://learn.microsoft.com/en-us/microsoftteams/platform/sbs-meetings-sidepanel?tabs=vs)
 - [Handle theme change](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/access-teams-context?tabs=Json-v2%2Cteamsjs-v2%2Cdefault#handle-theme-change)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meeting-tabs-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meeting-tabs-python" />

--- a/samples/TeamsJS/meetings-context-app/csharp/README.md
+++ b/samples/TeamsJS/meetings-context-app/csharp/README.md
@@ -30,7 +30,7 @@ This sample application illustrates how to display the contents of the meeting c
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Teams Meeting Context Sample:** [Manifest](/samples/meetings-context-app/csharp/demo-manifest/meetings-context-app.zip)
+**Teams Meeting Context Sample:** [Manifest](/samples/TeamsJS/meetings-context-app/csharp/demo-manifest/meetings-context-app.zip)
  
 ## Prerequisites
 
@@ -146,7 +146,7 @@ Here is the exact content that must be added if it’s missing or incomplete:
 - Add the app in meeting.
 
  **NOTE:** Only accounts with admin access can create private/shared channels in team.
- - If you are facing any issue in your app,  please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meetings-context-app/csharp/MeetingContextApp/AdapterWithErrorHandler.cs#L24) line and put your debugger for local debug.
+ - If you are facing any issue in your app,  please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meetings-context-app/csharp/MeetingContextApp/AdapterWithErrorHandler.cs#L24) line and put your debugger for local debug.
     
 
 ## Running the sample
@@ -174,4 +174,4 @@ Here is the exact content that must be added if it’s missing or incomplete:
 - [Meeting API reference](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/api-references?tabs=dotnet)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-context-app-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-context-app-csharp" />

--- a/samples/TeamsJS/meetings-context-app/nodejs/README.md
+++ b/samples/TeamsJS/meetings-context-app/nodejs/README.md
@@ -30,7 +30,7 @@ This sample application illustrates how to display the meeting context object in
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Teams Meeting Context Sample:** [Manifest](/samples/meetings-context-app/csharp/demo-manifest/meetings-context-app.zip)
+**Teams Meeting Context Sample:** [Manifest](/samples/TeamsJS/meetings-context-app/csharp/demo-manifest/meetings-context-app.zip)
 
 ## Prerequisites
 
@@ -163,7 +163,7 @@ Here is the exact content that must be added if it’s missing or incomplete:
 2. **Meeting Details :** In this user can track the detials of meeting start time, end time, joining url and other details respectively.
 ![meeting context](Images/Meeting-Details.png) 
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meetings-context-app/nodejs/server/index.js#L44) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meetings-context-app/nodejs/server/index.js#L44) line and put your debugger for local debug.
 
 ## Further reading
 
@@ -172,4 +172,4 @@ Here is the exact content that must be added if it’s missing or incomplete:
 - [Get-context-for-tabs](https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/access-teams-context#retrieve-context-in-private-channels)
 - [Meeting API reference](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/api-references?tabs=dotnet)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-context-app-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-context-app-nodejs" />

--- a/samples/TeamsJS/meetings-context-app/python/README.md
+++ b/samples/TeamsJS/meetings-context-app/python/README.md
@@ -37,7 +37,7 @@ This sample application illustrates how to display the meeting context object in
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Teams Meeting Context Sample:** [Manifest](/samples/meetings-context-app/csharp/demo-manifest/meetings-context-app.zip)
+**Teams Meeting Context Sample:** [Manifest](/samples/TeamsJS/meetings-context-app/csharp/demo-manifest/meetings-context-app.zip)
 
 ## Prerequisites
 
@@ -161,4 +161,4 @@ To learn more about deploying a bot to Azure, see [Deploy your bot to Azure](htt
 - [Azure Bot Service Documentation](https://docs.microsoft.com/azure/bot-service/?view=azure-bot-service-4.0)
 - [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/en-us/microsoftteams/platform/m365-apps/overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-context-app-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-context-app-python" />

--- a/samples/TeamsJS/meetings-details-tab/csharp/README.md
+++ b/samples/TeamsJS/meetings-details-tab/csharp/README.md
@@ -29,7 +29,7 @@ This sample application showcases the extensibility of Microsoft Teams meetings 
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meetings Details Tab Sample:** [Manifest](/samples/meetings-details-tab/csharp/demo-manifest/meetings-details-tab.zip)
+**Meetings Details Tab Sample:** [Manifest](/samples/TeamsJS/meetings-details-tab/csharp/demo-manifest/meetings-details-tab.zip)
 
 ## Prerequisites
 
@@ -139,7 +139,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
    - Go to your project directory, the ./appPackage folder, select the zip folder, and choose Open.
    - Select Add in the pop-up dialog box. Your app is uploaded to Teams.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meetings-details-tab/csharp/DetailsTab/AdapterWithErrorHandler.cs#L25) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meetings-details-tab/csharp/DetailsTab/AdapterWithErrorHandler.cs#L25) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -163,4 +163,4 @@ Interact with Details Tab in Meeting.
 - [Meeting Side Panel](https://learn.microsoft.com/microsoftteams/platform/sbs-meetings-sidepanel?tabs=vs)
 - [Install the App in Teams Meeting](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/teams-apps-in-meetings?view=msteams-client-js-latest#meeting-lifecycle-scenarios)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-details-tab-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-details-tab-csharp" />

--- a/samples/TeamsJS/meetings-details-tab/nodejs/Readme.md
+++ b/samples/TeamsJS/meetings-details-tab/nodejs/Readme.md
@@ -29,7 +29,7 @@ This sample demonstrates how to extend Microsoft Teams meetings by implementing 
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meetings Details Tab Sample:** [Manifest](/samples/meetings-details-tab/csharp/demo-manifest/meetings-details-tab.zip)
+**Meetings Details Tab Sample:** [Manifest](/samples/TeamsJS/meetings-details-tab/csharp/demo-manifest/meetings-details-tab.zip)
 
 ## Prerequisites
 
@@ -142,7 +142,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
    - Go to your project directory, the ./appManifest folder, select the zip folder, and choose Open.
    - Select Add in the pop-up dialog box. Your app is uploaded to Teams.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meetings-details-tab/nodejs/server/api/botController.js#L24) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meetings-details-tab/nodejs/server/api/botController.js#L24) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -179,4 +179,4 @@ Interact with Details Tab in Meeting.
 - [Meeting Side Panel](https://learn.microsoft.com/microsoftteams/platform/sbs-meetings-sidepanel?tabs=vs)
 - [Install the App in Teams Meeting](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/teams-apps-in-meetings?view=msteams-client-js-latest#meeting-lifecycle-scenarios)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-details-tab-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-details-tab-nodejs" />

--- a/samples/TeamsJS/meetings-details-tab/python/README.md
+++ b/samples/TeamsJS/meetings-details-tab/python/README.md
@@ -31,7 +31,7 @@ This sample demonstrates how to extend Microsoft Teams meetings by implementing 
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meetings Details Tab Sample:** [Manifest](/samples/meetings-details-tab/python-backend/demo-manifest/meetings-details-tab.zip)
+**Meetings Details Tab Sample:** [Manifest](/samples/TeamsJS/meetings-details-tab/csharp/demo-manifest/meetings-details-tab.zip)
 
 ## Prerequisites
 
@@ -204,4 +204,4 @@ Interact with Details Tab in Meeting.
 - [Flask Documentation](https://flask.palletsprojects.com/)
 - [Bot Framework Python SDK](https://docs.microsoft.com/azure/bot-service/python/bot-builder-python-quickstart?view=azure-bot-service-4.0)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-details-tab-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-details-tab-python" />

--- a/samples/TeamsJS/meetings-live-code-interview/csharp/README.md
+++ b/samples/TeamsJS/meetings-live-code-interview/csharp/README.md
@@ -30,7 +30,7 @@ This sample application demonstrates how to conduct live coding interviews in Mi
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Live coding interview using Shared meeting stage:** [Manifest](/samples/meetings-live-code-interview/csharp/demo-manifest/meetings-live-code-interview.zip)
+**Live coding interview using Shared meeting stage:** [Manifest](/samples/TeamsJS/meetings-live-code-interview/csharp/demo-manifest/meetings-live-code-interview.zip)
 
 ## Prerequisites
 
@@ -187,4 +187,4 @@ sequenceDiagram
 - [Enable-and-configure-your-app-for-teams-meetings](https://docs.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings)
 - [Live-share-sdk-overview](https://docs.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/teams-live-share-overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-live-code-interview-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-live-code-interview-csharp" />

--- a/samples/TeamsJS/meetings-live-code-interview/nodejs/README.md
+++ b/samples/TeamsJS/meetings-live-code-interview/nodejs/README.md
@@ -31,7 +31,7 @@ This sample application facilitates live coding interviews in Microsoft Teams us
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Live coding interview using Shared meeting stage:** [Manifest](/samples/meetings-live-code-interview/csharp/demo-manifest/meetings-live-code-interview.zip)
+**Live coding interview using Shared meeting stage:** [Manifest](/samples/TeamsJS/meetings-live-code-interview/csharp/demo-manifest/meetings-live-code-interview.zip)
 
 ## Prerequisites
 
@@ -175,4 +175,4 @@ sequenceDiagram
 - [Enable-and-configure-your-app-for-teams-meetings](https://docs.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/enable-and-configure-your-app-for-teams-meetings)
 - [Live-share-sdk-overview](https://docs.microsoft.com/en-us/microsoftteams/platform/apps-in-teams-meetings/teams-live-share-overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-live-code-interview-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-live-code-interview-nodejs" />

--- a/samples/TeamsJS/meetings-stage-view/csharp/README.md
+++ b/samples/TeamsJS/meetings-stage-view/csharp/README.md
@@ -38,7 +38,7 @@ This sample application enables the configuration and use of shared meeting stag
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Realtime meeting stage view:** [Manifest](/samples/meetings-stage-view/csharp/demo-manifest/Meeting-stage-view.zip)
+**Realtime meeting stage view:** [Manifest](/samples/TeamsJS/meetings-stage-view/csharp/demo-manifest/Meeting-stage-view.zip)
 
 ## Prerequisites
 
@@ -262,4 +262,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Deeplink to meeting share to stage](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/share-in-meeting?tabs=method-1#generate-a-deep-link-to-share-content-to-stage-in-meetings)
 - [Handle theme change](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/access-teams-context?tabs=Json-v2%2Cteamsjs-v2%2Cdefault#handle-theme-change)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-stage-view-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-stage-view-csharp" />

--- a/samples/TeamsJS/meetings-stage-view/nodejs/Readme.md
+++ b/samples/TeamsJS/meetings-stage-view/nodejs/Readme.md
@@ -42,7 +42,7 @@ This sample application [Enables the configuration](https://docs.microsoft.com/m
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Realtime meeting stage view:** [Manifest](/samples/meetings-stage-view/csharp/demo-manifest/Meeting-stage-view.zip)
+**Realtime meeting stage view:** [Manifest](/samples/TeamsJS/meetings-stage-view/csharp/demo-manifest/Meeting-stage-view.zip)
 
 ## Prerequisites
 
@@ -131,11 +131,11 @@ For reference please check [Share app content to stage API](https://docs.microso
 3) Search the uploaded app and copy the `App ID`
 ![Admin Center](Images/adminCenter.png)
 
-4) Navigate to `samples/samples/meetings-stage-view/nodejs/ClientApp/src/components/app-in-meeting.jsx`
+4) Navigate to `samples/samples/TeamsJS/meetings-stage-view/nodejs/ClientApp/src/components/app-in-meeting.jsx`
 
 5) On line 74, replace `<<App id>>` with `Id` obtained in step 3.
 
-6) Navigate to `samples/samples/meetings-stage-view/nodejs/ClientApp/src/components/share-to-meeting.jsx`
+6) Navigate to `samples/samples/TeamsJS/meetings-stage-view/nodejs/ClientApp/src/components/share-to-meeting.jsx`
 
 7) On line 25, replace `<Application-Base-URL>` with your application's base url whrre app is running. E.g. if you are using ngrok it would be something like `https://1234.ngrok-free.app` and if you are using dev tunnels, your URL will be like: https://12345.devtunnels.ms.
 
@@ -236,4 +236,4 @@ You can use this app by following the below steps:
 - [Deeplink to meeting share to stage](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/share-in-meeting?tabs=method-1#generate-a-deep-link-to-share-content-to-stage-in-meetings)
 - [Handle theme change](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/access-teams-context?tabs=Json-v2%2Cteamsjs-v2%2Cdefault#handle-theme-change)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-stage-view-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-stage-view-nodejs" />

--- a/samples/TeamsJS/meetings-stage-view/python/README.md
+++ b/samples/TeamsJS/meetings-stage-view/python/README.md
@@ -30,7 +30,7 @@ This sample application [Enables the configuration](https://docs.microsoft.com/m
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Realtime meeting stage view:** [Manifest](/samples/meetings-stage-view/python/demo-manifest/Meeting-stage-view.zip)
+**Realtime meeting stage view:** [Manifest](/samples/TeamsJS/meetings-stage-view/csharp/demo-manifest/Meeting-stage-view.zip)
 
 ## Prerequisites
 
@@ -138,11 +138,11 @@ For reference please check [Share app content to stage API](https://docs.microso
 3) Search the uploaded app and copy the `App ID`
 ![Admin Center](Images/adminCenter.png)
 
-4) Navigate to `samples/samples/meetings-stage-view/python/ClientApp/src/components/app-in-meeting.jsx`
+4) Navigate to `samples/samples/TeamsJS/meetings-stage-view/python/ClientApp/src/components/app-in-meeting.jsx`
 
 5) Replace `<<App id>>` with `Id` obtained in step 3.
 
-6) Navigate to `samples/samples/meetings-stage-view/python/ClientApp/src/components/share-to-meeting.jsx`
+6) Navigate to `samples/samples/TeamsJS/meetings-stage-view/python/ClientApp/src/components/share-to-meeting.jsx`
 
 7) Replace `<Application-Base-URL>` with your application's base url where app is running. E.g. if you are using ngrok it would be something like `https://1234.ngrok-free.app` and if you are using dev tunnels, your URL will be like: https://12345.devtunnels.ms.
 
@@ -199,4 +199,4 @@ You can use this app by following the below steps:
 - [Deeplink to meeting share to stage](https://learn.microsoft.com/microsoftteams/platform/concepts/build-and-test/share-in-meeting?tabs=method-1#generate-a-deep-link-to-share-content-to-stage-in-meetings)
 - [Handle theme change](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/access-teams-context?tabs=Json-v2%2Cteamsjs-v2%2Cdefault#handle-theme-change)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-stage-view-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-stage-view-python" />

--- a/samples/TeamsJS/meetings-token-app/csharp/README.md
+++ b/samples/TeamsJS/meetings-token-app/csharp/README.md
@@ -42,7 +42,7 @@ The Meeting Token Generator is a sample application designed to extend Microsoft
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meetings Token App:** [Manifest](/samples/meetings-token-app/csharp/demo-manifest/meetings-token-app.zip)
+**Meetings Token App:** [Manifest](/samples/TeamsJS/meetings-token-app/csharp/demo-manifest/meetings-token-app.zip)
 
 ## Prerequisites
 
@@ -187,7 +187,7 @@ Note: Open the meeting chat section and type @MeetingTokenApp Hello (It will sen
 
 > In-meeting tabs are only available in the Teams desktop client. They will not be visible when you run Teams in a web browser.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meetings-token-app/csharp/AdapterWithErrorHandler.cs#L32) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meetings-token-app/csharp/AdapterWithErrorHandler.cs#L32) line and put your debugger for local debug.
   
 -- Upload the app in a Teams desktop client
     1. Create a meeting with few test participants, ideally with a mix of Presenters and Attendees.
@@ -257,4 +257,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-token-app-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-token-app-csharp" />

--- a/samples/TeamsJS/meetings-token-app/nodejs/Readme.md
+++ b/samples/TeamsJS/meetings-token-app/nodejs/Readme.md
@@ -53,7 +53,7 @@ The Meeting Token Generator is a sample application designed to extend Microsoft
  ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Meetings Token App:** [Manifest](/samples/meetings-token-app/csharp/demo-manifest/meetings-token-app.zip)
+**Meetings Token App:** [Manifest](/samples/TeamsJS/meetings-token-app/csharp/demo-manifest/meetings-token-app.zip)
 
   
 ## Prerequisites
@@ -91,7 +91,7 @@ The app uses the Teams extensibility features described on the following pages:
 - [Apps in Teams meetings](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/teams-apps-in-meetings)
 - [Create apps for Teams meetings](https://docs.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/create-apps-for-teams-meetings?tabs=json)
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/meetings-token-app/nodejs/server/api/botController.js#L25) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/meetings-token-app/nodejs/server/api/botController.js#L25) line and put your debugger for local debug.
 
 ## Setup
 
@@ -248,4 +248,4 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/meetings-token-app-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/meetings-token-app-nodejs" />

--- a/samples/TeamsJS/tab-app-monetization/nodejs/README.md
+++ b/samples/TeamsJS/tab-app-monetization/nodejs/README.md
@@ -28,7 +28,7 @@ Explore a sample Teams tab application that illustrates how to implement app mon
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**App monetization in tab:** [Manifest](/samples/tab-app-monetization/nodejs/demo-manifest/tab-app-monetization.zip)
+**App monetization in tab:** [Manifest](/samples/TeamsJS/tab-app-monetization/nodejs/demo-manifest/tab-app-monetization.zip)
 
 ## Prerequisites
 
@@ -138,4 +138,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Tab Basics](https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script)
 - [Azure Portal](https://portal.azure.com)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-app-monetization-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-app-monetization-nodejs" />

--- a/samples/TeamsJS/tab-channel-group-quickstart/csharp/README.md
+++ b/samples/TeamsJS/tab-channel-group-quickstart/csharp/README.md
@@ -26,7 +26,7 @@ Explore this simple hello world app that showcases channel and group tabs in Mic
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Tab Channel quick start:** [Manifest](/samples/tab-channel-group-quickstart/csharp/demo-manifest/tab-channel-group-quickstart.zip)
+**Tab Channel quick start:** [Manifest](/samples/TeamsJS/tab-channel-group-quickstart/js/demo-manifest/tab-channel-group-quickstart.zip)
 
 ## Prerequisites
 - Microsoft Teams is installed and you have an account (not a guest account)
@@ -151,4 +151,4 @@ To learn more about deploying an app to Azure, see [Deploy your app to Azure](ht
 - [Create a group tab](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script)
 - [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/en-us/microsoftteams/platform/m365-apps/overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-quickstart-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-quickstart-csharp" />

--- a/samples/TeamsJS/tab-channel-group-quickstart/js/README.md
+++ b/samples/TeamsJS/tab-channel-group-quickstart/js/README.md
@@ -28,7 +28,7 @@ This sample application illustrates how to create channel and group tabs in Micr
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Tab Channel quick start:** [Manifest](/samples/tab-channel-group-quickstart/js/demo-manifest/tab-channel-group-quickstart.zip)
+**Tab Channel quick start:** [Manifest](/samples/TeamsJS/tab-channel-group-quickstart/js/demo-manifest/tab-channel-group-quickstart.zip)
 
 ## Prerequisites
 
@@ -149,4 +149,4 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 [Create a group tab](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-quickstart-js" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-quickstart-js" />

--- a/samples/TeamsJS/tab-channel-group-quickstart/python/README.md
+++ b/samples/TeamsJS/tab-channel-group-quickstart/python/README.md
@@ -28,7 +28,7 @@ This sample application illustrates how to create channel and group tabs in Micr
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Tab Channel quick start:** [Manifest](/samples/tab-channel-group-quickstart/python/demo-manifest/tab-channel-group-quickstart.zip)
+**Tab Channel quick start:** [Manifest](/samples/TeamsJS/tab-channel-group-quickstart/js/demo-manifest/tab-channel-group-quickstart.zip)
 
 ## Prerequisites
 
@@ -169,4 +169,4 @@ Ensure you have the Python extension installed for Visual Studio Code from the m
 
 [Create a group tab](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-quickstart-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-quickstart-python" />

--- a/samples/TeamsJS/tab-channel-group-quickstart/ts/README.md
+++ b/samples/TeamsJS/tab-channel-group-quickstart/ts/README.md
@@ -28,7 +28,7 @@ Explore this simple app that showcases channel and group tabs in Microsoft Teams
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Tab Channel quick start:** [Manifest](/samples/tab-channel-group-quickstart/js/demo-manifest/tab-channel-group-quickstart.zip)
+**Tab Channel quick start:** [Manifest](/samples/TeamsJS/tab-channel-group-quickstart/js/demo-manifest/tab-channel-group-quickstart.zip)
 
 ## Prerequisites
 - Microsoft Teams is installed and you have an account (not a guest account)
@@ -150,4 +150,4 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 [Create a group tab](https://learn.microsoft.com/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-quickstart-ts" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-quickstart-ts" />

--- a/samples/TeamsJS/tab-channel-group-sso-quickstart/csharp_dotnetcore/README.md
+++ b/samples/TeamsJS/tab-channel-group-sso-quickstart/csharp_dotnetcore/README.md
@@ -24,7 +24,7 @@ Discover this sample application that demonstrates Microsoft Entra SSO authentic
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant; [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading).).
 
-**Channel and group tab with SSO quick-start:** [Manifest](/samples/tab-channel-group-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-channel-group-sso-quickstart.zip)
+**Channel and group tab with SSO quick-start:** [Manifest](/samples/TeamsJS/tab-channel-group-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-channel-group-sso-quickstart.zip)
 
 ## Prerequisites
 
@@ -175,4 +175,4 @@ This sample illustrates how to implement SSO authentication for Teams Tab.
 [Tab-channel-group-SSO-QuickStart](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-sso-quickstart-csharp_dotnetcore" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-sso-quickstart-csharp_dotnetcore" />

--- a/samples/TeamsJS/tab-channel-group-sso-quickstart/js/README.md
+++ b/samples/TeamsJS/tab-channel-group-sso-quickstart/js/README.md
@@ -25,7 +25,7 @@ Explore this sample application that showcases Microsoft Entra SSO authenticatio
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant; [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading).).
 
-**Channel and group tab with SSO quick-start:** [Manifest](/samples/tab-channel-group-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-channel-group-sso-quickstart.zip)
+**Channel and group tab with SSO quick-start:** [Manifest](/samples/TeamsJS/tab-channel-group-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-channel-group-sso-quickstart.zip)
 
 ## Prerequisites
 -  [NodeJS](https://nodejs.org/en/)
@@ -164,4 +164,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 [Tab-channel-group-sso-quickstart](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-sso-quickstart-js" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-sso-quickstart-js" />

--- a/samples/TeamsJS/tab-channel-group-sso-quickstart/ts/README.md
+++ b/samples/TeamsJS/tab-channel-group-sso-quickstart/ts/README.md
@@ -25,7 +25,7 @@ Explore this sample application that demonstrates Microsoft Entra SSO authentica
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant; [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading).).
 
-**Channel and group tab with SSO quick-start:** [Manifest](/samples/tab-channel-group-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-channel-group-sso-quickstart.zip)
+**Channel and group tab with SSO quick-start:** [Manifest](/samples/TeamsJS/tab-channel-group-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-channel-group-sso-quickstart.zip)
 
 ## Prerequisites
 - Microsoft Teams is installed and you have an account (not a guest account)
@@ -194,4 +194,4 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-sso-quickstart-ts" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-sso-quickstart-ts" />

--- a/samples/TeamsJS/tab-channel-group/mvc-csharp/README.md
+++ b/samples/TeamsJS/tab-channel-group/mvc-csharp/README.md
@@ -56,7 +56,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Channel and group tabs in ASP.NET Core with MVC:** [Manifest](/samples/tab-channel-group/mvc-csharp/demo-manifest/tab-channel-group.zip)
+**Channel and group tabs in ASP.NET Core with MVC:** [Manifest](/samples/TeamsJS/tab-channel-group/mvc-csharp/demo-manifest/tab-channel-group.zip)
 
 ## Setup
 
@@ -130,4 +130,4 @@ Please find below demo manifest which is deployed on Microsoft Azure and you can
 [Tab-channel-group](https://learn.microsoft.coms/microsoftteams/platform/tabs/what-are-tabs)
 [Create a Custom Channel and Group Tab with ASP.NET Core and MVC](https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=mvc-csharp)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-mvc-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-mvc-csharp" />

--- a/samples/TeamsJS/tab-channel-group/nodejs/README.md
+++ b/samples/TeamsJS/tab-channel-group/nodejs/README.md
@@ -28,7 +28,7 @@ Discover how to create custom channel and group tabs in Microsoft Teams using No
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Channel and group tabs in Node.js:**  [Manifest](/samples/tab-channel-group/js/demo-manifest/tab-channel-group.zip)
+**Channel and group tabs in Node.js:**  [Manifest](/samples/TeamsJS/tab-channel-group/mvc-csharp/demo-manifest/tab-channel-group.zip)
 
 ## Prerequisites
 
@@ -128,4 +128,4 @@ Your app is ready to be deployed!
 - [Tab-channel-group](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/what-are-tabs)
 - [Create a Custom Channel and Group Tab with Node.js](https://docs.microsoft.com/microsoftteams/platform/tabs/how-to/create-channel-group-tab?pivots=node-java-script&tabs=vs)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-js" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-js" />

--- a/samples/TeamsJS/tab-channel-group/razor-csharp/README.md
+++ b/samples/TeamsJS/tab-channel-group/razor-csharp/README.md
@@ -27,7 +27,7 @@ Explore how to create custom channel and group tabs for Microsoft Teams using AS
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Channel and group tabs in ASP.NET Core with MVC:** [Manifest](/samples/tab-channel-group/mvc-csharp/demo-manifest/tab-channel-group.zip)
+**Channel and group tabs in ASP.NET Core with MVC:** [Manifest](/samples/TeamsJS/tab-channel-group/mvc-csharp/demo-manifest/tab-channel-group.zip)
 
 ## Prerequisites
 
@@ -134,4 +134,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-razor-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-razor-csharp" />

--- a/samples/TeamsJS/tab-channel-group/spfx/README.md
+++ b/samples/TeamsJS/tab-channel-group/spfx/README.md
@@ -26,7 +26,7 @@ Discover how to build Microsoft Teams tabs using the SharePoint Framework in thi
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Channel and group tabs in ASP.NET Core with MVC:** [Manifest](/samples/tab-channel-group/mvc-csharp/demo-manifest/tab-channel-group.zip)
+**Channel and group tabs in ASP.NET Core with MVC:** [Manifest](/samples/TeamsJS/tab-channel-group/mvc-csharp/demo-manifest/tab-channel-group.zip)
 
 ## Prerequisites
 - [App Catalog site](https://docs.microsoft.com/sharepoint/dev/spfx/set-up-your-developer-tenant#create-app-catalog-site)
@@ -172,4 +172,4 @@ For more information about getting started with Teams-sharepoint, please review 
 - [Publish SharePoint Framework applications to the Marketplace](https://docs.microsoft.com/sharepoint/dev/spfx/publish-to-marketplace-overview)
 - [Microsoft 365 Patterns and Practices](https://aka.ms/m365pnp) - Guidance, tooling, samples and open-source controls for your Microsoft 365 development
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-channel-group-spfx" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-channel-group-spfx" />

--- a/samples/TeamsJS/tab-device-permissions/nodejs/README.md
+++ b/samples/TeamsJS/tab-device-permissions/nodejs/README.md
@@ -38,7 +38,7 @@ Currently only capture image is supported in Teams Desktop client.
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Tab Device Permission:** [Manifest](/samples/tab-device-permissions/nodejs/demo-manifest/tab-device-permissions.zip)
+**Tab Device Permission:** [Manifest](/samples/TeamsJS/tab-device-permissions/nodejs/demo-manifest/tab-device-permissions.zip)
 
 ## Prerequisites
  To test locally, [NodeJS](https://nodejs.org/en/download/) must be installed on your development machine (version 16.14.2  or higher).
@@ -198,4 +198,4 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 - [Teams tabs](https://learn.microsoft.com/microsoftteams/platform/tabs/what-are-tabs)
 - [Integrate media Capabilities inside your app](https://learn.microsoft.com/microsoftteams/platform/concepts/device-capabilities/media-capabilities?tabs=mobile)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-device-permissions-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-device-permissions-nodejs" />

--- a/samples/TeamsJS/tab-device-permissions/python/README.md
+++ b/samples/TeamsJS/tab-device-permissions/python/README.md
@@ -35,7 +35,7 @@ Currently only capture image is supported in Teams Desktop client.
 
 ![Tab Device PermissionsGif Mobile](Images/TabDevicePermissionsGifMobile.gif)
 
-**Deployed App Manifest (Tab Device Permission):** [Manifest](/samples/tab-device-permissions/nodejs/demo-manifest/tab-device-permissions.zip)  
+**Deployed App Manifest (Tab Device Permission):** [Manifest](/samples/TeamsJS/tab-device-permissions/nodejs/demo-manifest/tab-device-permissions.zip)  
 
 Download and upload this manifest to Microsoft Teams for testing.  
 The app is already deployed and hosted on Azure App Service, ready for immediate use.
@@ -191,4 +191,4 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 - [Teams tabs](https://learn.microsoft.com/microsoftteams/platform/tabs/what-are-tabs)
 - [Integrate media Capabilities inside your app](https://learn.microsoft.com/microsoftteams/platform/concepts/device-capabilities/media-capabilities?tabs=mobile)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-device-permissions-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-device-permissions-python" />

--- a/samples/TeamsJS/tab-nested-auth/csharp/README.md
+++ b/samples/TeamsJS/tab-nested-auth/csharp/README.md
@@ -22,7 +22,7 @@ This sample application for Microsoft Teams illustrates how to implement Azure A
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Nested app authentication:** [Manifest](/samples/tab-nested-auth/csharp/demo-manifest/tab-nested-auth.zip)
+**Nested app authentication:** [Manifest](/samples/TeamsJS/tab-nested-auth/csharp/demo-manifest/tab-nested-auth.zip)
 
 ## Run the app (Using Microsoft 365 Agents Toolkit for Visual Studio)
 
@@ -86,7 +86,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
     
 4. Run the app from a terminal or from Visual Studio, choose option A or B.
 
-    A) From a terminal, navigate to `/samples/tab-nested-auth/csharp`
+    A) From a terminal, navigate to `/samples/TeamsJS/tab-nested-auth/csharp`
 
     ```bash
     # run the app
@@ -96,7 +96,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
     - Launch Visual Studio
     - File -> Open -> Project/Solution
-    - Navigate to `/samples/tab-nested-auth/csharp` folder
+    - Navigate to `/samples/TeamsJS/tab-nested-auth/csharp` folder
     - Select `TabNestedAuth.sln` file
     - Press `F5` to run the project
     
@@ -152,4 +152,4 @@ In the debug dropdown menu of Visual Studio, select default startup project > **
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-nested-auth-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-nested-auth-csharp" />

--- a/samples/TeamsJS/tab-nested-auth/nodejs/README.md
+++ b/samples/TeamsJS/tab-nested-auth/nodejs/README.md
@@ -24,7 +24,7 @@ Nested app authentication (NAA) is a new authentication protocol for single page
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Nested app authentication:** [Manifest](/samples/tab-nested-auth/csharp/demo-manifest/tab-nested-auth.zip)
+**Nested app authentication:** [Manifest](/samples/TeamsJS/tab-nested-auth/csharp/demo-manifest/tab-nested-auth.zip)
 
 ## Prerequisites
 
@@ -158,4 +158,4 @@ To debug the app
 
 - [SPA Redirect URL](https://learn.microsoft.com/en-us/office/dev/add-ins/develop/enable-nested-app-authentication-in-your-add-in#add-a-trusted-broker-through-spa-redirect)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-nested-auth-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-nested-auth-nodejs" />

--- a/samples/TeamsJS/tab-people-picker/csharp/README.md
+++ b/samples/TeamsJS/tab-people-picker/csharp/README.md
@@ -28,7 +28,7 @@ This sample application highlights the People Picker feature within a Microsoft 
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Tab people picker:** [Manifest](/samples/tab-people-picker/csharp/demo-manifest/Tab-People-Picker.zip)
+**Tab people picker:** [Manifest](/samples/TeamsJS/tab-people-picker/csharp/demo-manifest/Tab-People-Picker.zip)
 
 ## Prerequisites
 
@@ -102,7 +102,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
     ```
 - Run the bot from a terminal or from Visual Studio:
 
-  - From a terminal, navigate to `samples/samples/tab-people-picker/csharp`
+  - From a terminal, navigate to `samples/samples/TeamsJS/tab-people-picker/csharp`
 
   ```bash
   # run the bot
@@ -148,4 +148,4 @@ This is an tab app which shows the feature of client sdk people picker.
 
 [Tab-people-picker](https://learn.microsoft.com/en-us/microsoftteams/platform/concepts/device-capabilities/people-picker-capability?tabs=Samplemobileapp%2Cteamsjs-v2)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-people-picker-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-people-picker-csharp" />

--- a/samples/TeamsJS/tab-people-picker/nodejs/Readme.md
+++ b/samples/TeamsJS/tab-people-picker/nodejs/Readme.md
@@ -28,7 +28,7 @@ urlFragment: officedev-microsoft-teams-samples-tab-people-picker-nodejs
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Tab people picker:** [Manifest](/samples/tab-people-picker/csharp/demo-manifest/Tab-People-Picker.zip)
+**Tab people picker:** [Manifest](/samples/TeamsJS/tab-people-picker/csharp/demo-manifest/Tab-People-Picker.zip)
 
 ## Prerequisites
 
@@ -146,4 +146,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 - [Tab Pepole picker](https://learn.microsoft.com/microsoftteams/platform/concepts/device-capabilities/people-picker-capability?tabs=Samplemobileapp%2Cteamsjs-v2)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-people-picker-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-people-picker-nodejs" />

--- a/samples/TeamsJS/tab-personal-sso-quickstart/csharp_dotnetcore/README.md
+++ b/samples/TeamsJS/tab-personal-sso-quickstart/csharp_dotnetcore/README.md
@@ -29,7 +29,7 @@ urlFragment: officedev-microsoft-teams-samples-tab-personal-sso-quickstart-cshar
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant; [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Personal tab with SSO quick-start:** [Manifest](/samples/tab-personal-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-personal-sso-quickstart.zip)
+**Personal tab with SSO quick-start:** [Manifest](/samples/TeamsJS/tab-personal-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-personal-sso-quickstart.zip)
  
 ## Prerequisites
 
@@ -219,4 +219,4 @@ In Teams, Once the app is succefully installed, it can be opened and the tab sho
 - [Microsoft Teams Developer Platform](https://docs.microsoft.com/en-us/microsoftteams/platform/)
 - [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/en-us/microsoftteams/platform/m365-apps/overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-personal-sso-quickstart-csharp_dotnetcore" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-personal-sso-quickstart-csharp_dotnetcore" />

--- a/samples/TeamsJS/tab-personal-sso-quickstart/js/README.md
+++ b/samples/TeamsJS/tab-personal-sso-quickstart/js/README.md
@@ -30,7 +30,7 @@ This sample application serves as a complete guide for implementing Single Sign-
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant; [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Personal tab with SSO quick-start:** [Manifest](/samples/tab-personal-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-personal-sso-quickstart.zip)
+**Personal tab with SSO quick-start:** [Manifest](/samples/TeamsJS/tab-personal-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-personal-sso-quickstart.zip)
 
  ## Prerequisites
 
@@ -185,4 +185,4 @@ Ensure you have the Debugger for Chrome/Edge extension installed for Visual Stud
 [Tab-personal-quickStart](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/how-to/authentication/tab-sso-overview)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-personal-sso-quickstart-js" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-personal-sso-quickstart-js" />

--- a/samples/TeamsJS/tab-personal-sso-quickstart/ts/README.md
+++ b/samples/TeamsJS/tab-personal-sso-quickstart/ts/README.md
@@ -30,7 +30,7 @@ This sample application serves as a complete guide for implementing Single Sign-
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant; [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Personal tab with SSO quick-start:** [Manifest](/samples/tab-personal-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-personal-sso-quickstart.zip)
+**Personal tab with SSO quick-start:** [Manifest](/samples/TeamsJS/tab-personal-sso-quickstart/csharp_dotnetcore/demo-manifest/tab-personal-sso-quickstart.zip)
 
  ## Prerequisites
 
@@ -199,4 +199,4 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-personal-sso-quickstart-ts" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-personal-sso-quickstart-ts" />

--- a/samples/TeamsJS/tab-product-inspection/csharp/README.md
+++ b/samples/TeamsJS/tab-product-inspection/csharp/README.md
@@ -28,7 +28,7 @@ This sample application provides a seamless product inspection experience within
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Product Inspection:** [Manifest](/samples/tab-product-inspection/csharp/demo-manifest/Tab-Product-Inspection.zip)
+**Product Inspection:** [Manifest](/samples/TeamsJS/tab-product-inspection/csharp/demo-manifest/Tab-Product-Inspection.zip)
 
 ## Prerequisites
 - Microsoft Teams is installed and you have an account (not a guest account)
@@ -171,4 +171,4 @@ Interact with Product Inspection by clicking on the App icon.
 [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/microsoftteams/platform/m365-apps/overview)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-product-inspection-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-product-inspection-csharp" />

--- a/samples/TeamsJS/tab-product-inspection/nodejs/Readme.md
+++ b/samples/TeamsJS/tab-product-inspection/nodejs/Readme.md
@@ -27,7 +27,7 @@ This sample application provides a streamlined product inspection process in Mic
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Product Inspection:** [Manifest](/samples/tab-product-inspection/csharp/demo-manifest/Tab-Product-Inspection.zip)
+**Product Inspection:** [Manifest](/samples/TeamsJS/tab-product-inspection/csharp/demo-manifest/Tab-Product-Inspection.zip)
 
 ## Prerequisites
 
@@ -169,4 +169,4 @@ Interact with Product Inspection by clicking on the App icon.
 
 [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/microsoftteams/platform/m365-apps/overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-product-inspection-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-product-inspection-nodejs" />

--- a/samples/TeamsJS/tab-request-approval/csharp/README.md
+++ b/samples/TeamsJS/tab-request-approval/csharp/README.md
@@ -29,7 +29,7 @@ This sample application streamlines the task approval process in Microsoft Teams
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Send task approvals using activity feed notification:** [Manifest](/samples/tab-request-approval/csharp/demo-manifest/Tab-Request-Approval.zip)
+**Send task approvals using activity feed notification:** [Manifest](/samples/TeamsJS/tab-request-approval/csharp/demo-manifest/Tab-Request-Approval.zip)
 
 ## Prerequisites
 
@@ -165,7 +165,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 **Note:** App should be installed for user's manager also to get task approval notification.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/tab-request-approval/csharp/TabRequestApproval/AdapterWithErrorHandler.cs#L26) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/tab-request-approval/csharp/TabRequestApproval/AdapterWithErrorHandler.cs#L26) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -221,4 +221,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Send Notification to User](https://docs.microsoft.com/graph/api/userteamwork-sendactivitynotification?view=graph-rest-beta&tabs=http)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-request-approval-csharp" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-request-approval-csharp" />

--- a/samples/TeamsJS/tab-request-approval/nodejs/Readme.md
+++ b/samples/TeamsJS/tab-request-approval/nodejs/Readme.md
@@ -28,7 +28,7 @@ This sample has been created using [Microsoft Graph](https://docs.microsoft.com/
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Send task approvals using activity feed notification:** [Manifest](/samples/tab-request-approval/csharp/demo-manifest/Tab-Request-Approval.zip)
+**Send task approvals using activity feed notification:** [Manifest](/samples/TeamsJS/tab-request-approval/csharp/demo-manifest/Tab-Request-Approval.zip)
 
 ## Prerequisites
 
@@ -156,7 +156,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 **Note:** App should be installed for user's manager also to get task approval notification.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/msteams-application-resourcehub/Source/microsoft-teams-apps-selfhelp/Bot/AdapterWithErrorHandler.cs#L26) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/msteams-application-resourcehub/Source/microsoft-teams-apps-selfhelp/Bot/AdapterWithErrorHandler.cs#L26) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -216,4 +216,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Send Notification to User](https://docs.microsoft.com/graph/api/userteamwork-sendactivitynotification?view=graph-rest-beta&tabs=http)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-request-approval-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-request-approval-nodejs" />

--- a/samples/TeamsJS/tab-request-approval/python/Readme.md
+++ b/samples/TeamsJS/tab-request-approval/python/Readme.md
@@ -28,7 +28,7 @@ This sample has been created using [Microsoft Graph](https://docs.microsoft.com/
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Send task approvals using activity feed notification:** [Manifest](/samples/tab-request-approval/csharp/demo-manifest/Tab-Request-Approval.zip)
+**Send task approvals using activity feed notification:** [Manifest](/samples/TeamsJS/tab-request-approval/csharp/demo-manifest/Tab-Request-Approval.zip)
 
 ## Prerequisites
 
@@ -158,7 +158,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 **Note:** App should be installed for user's manager also to get task approval notification.
 
-**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/msteams-application-resourcehub/Source/microsoft-teams-apps-selfhelp/Bot/AdapterWithErrorHandler.cs#L26) line and put your debugger for local debug.
+**Note**: If you are facing any issue in your app, please uncomment [this](https://github.com/OfficeDev/Microsoft-Teams-Samples/blob/main/samples/TeamsJS/msteams-application-resourcehub/Source/microsoft-teams-apps-selfhelp/Bot/AdapterWithErrorHandler.cs#L26) line and put your debugger for local debug.
 
 ## Running the sample
 
@@ -198,4 +198,4 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 - [Send Notification to User](https://docs.microsoft.com/graph/api/userteamwork-sendactivitynotification?view=graph-rest-beta&tabs=http)
 
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-request-approval-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-request-approval-python" />

--- a/samples/TeamsJS/tab-support-offline/nodejs/README.md
+++ b/samples/TeamsJS/tab-support-offline/nodejs/README.md
@@ -29,7 +29,7 @@ This sample app illustrates a robust CRUD application that operates effectively 
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Microsoft Teams offline support tickets sample app:** [Manifest](/samples/tab-support-offline/nodejs/demo-manifest/tab-support-offline.zip)
+**Microsoft Teams offline support tickets sample app:** [Manifest](/samples/TeamsJS/tab-support-offline/nodejs/demo-manifest/tab-support-offline.zip)
 
 ## Prerequisites
 
@@ -281,4 +281,4 @@ You can interact with Teams Tab meeting sidepanel.
 - [Tab](https://learn.microsoft.com/en-us/microsoftteams/platform/tabs/what-are-tabs?tabs=personal)
 - [Create an Azure storage account](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-create?tabs=azure-portal)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-support-offline-nodejs" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-support-offline-nodejs" />

--- a/samples/TeamsJS/tab-ui-templates/python/README.md
+++ b/samples/TeamsJS/tab-ui-templates/python/README.md
@@ -28,7 +28,7 @@ This sample app illustrates best practices for designing applications within Mic
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Sideloading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Teams UI templates:** [Manifest](/samples/tab-ui-templates/ts/demo-manifest/tab-ui-templates.zip)
+**Teams UI templates:** [Manifest](/samples/TeamsJS/tab-ui-templates/ts/demo-manifest/tab-ui-templates.zip)
 
 ## Prerequisites
 
@@ -173,4 +173,4 @@ the Teams service needs to call into the bot.
 - [Tabs](https://learn.microsoft.com/microsoftteams/platform/tabs/what-are-tabs)
 - [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/microsoftteams/platform/m365-apps/overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-ui-templates-python" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-ui-templates-python" />

--- a/samples/TeamsJS/tab-ui-templates/ts/README.md
+++ b/samples/TeamsJS/tab-ui-templates/ts/README.md
@@ -29,7 +29,7 @@ This sample app illustrates best practices for designing applications within Mic
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app package (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**Teams UI templates:** [Manifest](/samples/tab-ui-templates/ts/demo-manifest/tab-ui-templates.zip)
+**Teams UI templates:** [Manifest](/samples/TeamsJS/tab-ui-templates/ts/demo-manifest/tab-ui-templates.zip)
 
 ## Prerequisites
 
@@ -44,7 +44,7 @@ Open a terminal and clone the sample app repository.
 
 ```bash
 git clone https://github.com/OfficeDev/Microsoft-Teams-Samples.git
-cd Microsoft-Teams-Samples/samples/tab-ui-templates/ts
+cd Microsoft-Teams-Samples/samples/TeamsJS/tab-ui-templates/ts
 yarn install
 ```
 
@@ -214,4 +214,4 @@ Teams doesn't display app content unless it's accessible via HTTPS. We recommend
 - [Tabs](https://learn.microsoft.com/microsoftteams/platform/tabs/what-are-tabs)
 - [Extend Teams apps across Microsoft 365](https://learn.microsoft.com/microsoftteams/platform/m365-apps/overview)
 
-<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/tab-ui-templates-ts" />
+<img src="https://pnptelemetry.azurewebsites.net/microsoft-teams-samples/samples/TeamsJS/tab-ui-templates-ts" />


### PR DESCRIPTION
## Summary

The reorganization of samples into the `TeamsJS/` subfolder (commit `753fa988a`) left demo-manifest zip links in 55 sample README files pointing to old paths that no longer exist.

This PR updates all 54 broken demo-manifest links across 55 README files in `samples/TeamsJS/` to use the correct `/samples/TeamsJS/` prefix.

Additionally, 5 links that referenced non-existent language-specific demo-manifest zips (e.g., `python/demo-manifest/` or `csharp/demo-manifest/` where no zip was created for that language) were corrected to point to the available sibling zip instead.

**All 25 unique corrected paths have been verified to point to files that exist in the repository.**

### Affected samples include:
- `app-sso`, `graph-rsc`, `graph-channel-lifecycle`, `graph-app-installation-lifecycle`
- `meeting-tabs`, `meeting-recruitment-app`, `meetings-context-app`, `meetings-details-tab`
- `meetings-stage-view`, `meetings-live-code-interview`, `meetings-token-app`
- `tab-channel-group`, `tab-channel-group-quickstart`, `tab-channel-group-sso-quickstart`
- `tab-personal-sso-quickstart`, `tab-device-permissions`, `tab-nested-auth`
- `tab-people-picker`, `tab-product-inspection`, `tab-request-approval`
- `tab-support-offline`, `tab-app-monetization`, `tab-ui-templates`

## Test plan

- [ ] Verify demo-manifest `[Manifest]` links in affected README files resolve correctly on GitHub
- [ ] Spot-check at least 5 different sample READMEs to confirm links download the correct zip
