### PR TITLE
Fix broken image paths in sample READMEs

### DIFF
--- a/samples/TeamsJS/user-scope-web-application/nodejs/README.md
+++ b/samples/TeamsJS/user-scope-web-application/nodejs/README.md
@@ -140,7 +140,7 @@ You can interact with user scope web application by logging with demo tenant.
 ![Sample](Images/3.LoginSuccess.png)
 
 1. **Group chat and messages**
-![Sample](Images/4.GroupChatsAndMessages.png)
+![Sample](Images/4,GroupChatsAndMessages.png)
 
 
 ## Further reading

--- a/samples/bot-archive-groupchat-messages/python/README.md
+++ b/samples/bot-archive-groupchat-messages/python/README.md
@@ -119,7 +119,7 @@ You can interact with this bot by sending it a message. The bot will respond by 
 
 **Set up a bot:**
 
-![Bot Setupbot](Images/setupbot.png)
+![Bot Setupbot](Images/setupbot.jpg)
 
 ![Bot Welcome](Images/welcome.png)
 

--- a/samples/bot-formatting-cards/python/README.md
+++ b/samples/bot-formatting-cards/python/README.md
@@ -297,7 +297,7 @@ the Teams service needs to call into the bot.
 
 **Gauge Chart :**
 
-![GaugeChart_Card](Images/24.GaugeChart_Card.png)
+![GaugeChart_Card](Images/24.GuageChart_Card.png)
 
 **Horizontal Chart :**
 

--- a/samples/bot-receive-channel-messages-withRSC/csharp/ReceiveMessagesWithRSC/README.md
+++ b/samples/bot-receive-channel-messages-withRSC/csharp/ReceiveMessagesWithRSC/README.md
@@ -7,7 +7,7 @@ This feature shown in this sample is currently available in Public Developer Pre
 
 - Showing messages based on option selected
 
-![Bot Receive Channel MessagesWithRSCGif](images/Bot_Channel_Messenging-RSC-nodejs-gif.gif)
+![Bot Receive Channel MessagesWithRSCGif](Images/Bot_Channel_Messenging-RSC.gif)
 
 ## Prerequisites
 

--- a/samples/bot-type-ahead-search-adaptive-cards/python/README.md
+++ b/samples/bot-type-ahead-search-adaptive-cards/python/README.md
@@ -133,15 +133,15 @@ On `Submit` button click, the bot will return the choice that we have selected.
 `Dependant Dropdown search:`
  Dependant typeahead search allows users to select data based on one of the dropdown. If the data of the main dropdown changes the data of the dependant dropdown changes with it. The data sets are loaded dynamically from the dataset specified in the card payload.
 
-![dependant dropdown search card](TypeaheadSearch/Images/9.DependantDropdown.png)
+![dependant dropdown search card](Images/9.DependantDropdown.png)
 
-![dependant dropdown search Countries](TypeaheadSearch/Images/10.CountryOptions.png)
+![dependant dropdown search Countries](Images/10.CountryOptions.png)
 
-![dependant dropdown search cities](TypeaheadSearch/Images/11.CitiesAsPerTheCountry.png)
+![dependant dropdown search cities](Images/11.CitiesAsPerTheCountry.png)
 
 `On `Submit` button click, the bot will return the choice that we have selected:`
 
-![dependant dropdown results](TypeaheadSearch/Images/12.SelectedDependantDropdown.png)
+![dependant dropdown results](Images/12.SelectedDependantDropdown.png)
 
 ## Deploy the bot to Azure
 

--- a/samples/connector-todo-notification/csharp/README.md
+++ b/samples/connector-todo-notification/csharp/README.md
@@ -74,7 +74,7 @@ The minimum prerequisites to run this sample are:
 
 4. Configure your own connector : 
   >**Note**:The below gif file shows a simple implementation of a connector registration implementation. It also sends a connector card to the registered       connector via a process triggered "externally". 
-  ![Connector_Configuration](TeamsToDoAppConnector/Images/Connector_Setup/connector_setup_csharp.gif)
+  ![Connector_Configuration](Images/Connector_Setup/connector_setup_csharp.gif)
    1. Register a new connector in the [Connector Developer Portal](https://aka.ms/connectorsdashboard)
    1. Fill in all the basic details such as name, logo, descriptions etc. for the new connector.
    1. For the configuration page, you'll use our sample code's setup endpoint: `https://[BASE_URI]/connector/setup`

--- a/samples/tab-personal/mvc-csharp/README.md
+++ b/samples/tab-personal/mvc-csharp/README.md
@@ -137,11 +137,11 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 **Click on 'Select Gray' button application will perform like below **
 
-![AppOutlook_Gray.png](Images/AppOutlook_Gray.png.png)
+![AppOutlook_Gray.png](Images/AppOutlook_Gray.png)
 
 **Click on 'Select Red' button application will perform like below **
 
-![AppOutlook_Red.png](Images/AppOutlook_Red.png.png)
+![AppOutlook_Red.png](Images/AppOutlook_Red.png)
 
 **Note:** Similarly, you can test your application in the Outlook desktop app as well.
 
@@ -161,11 +161,11 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
 
 **Click on 'Select Gray' button application will perform like below **
 
-![AppOffice_Gray.png](Images/AppOffice_Gray.png.png)
+![AppOffice_Gray.png](Images/AppOffice_Gray.png)
 
 **Click on 'Select Red' button application will perform like below **
 
-![AppOffice_Red.png](Images/AppOffice_Red.png.png)
+![AppOffice_Red.png](Images/AppOffice_Red.png)
 
 **Note:** Similarly, you can test your application in the Office 365 desktop app as well.
 


### PR DESCRIPTION
## Summary

Fixes broken image references across 7 sample READMEs where images fail to render on GitHub due to incorrect paths:

- **tab-personal/mvc-csharp** — 4 double `.png.png` extensions → `.png`
- **bot-receive-channel-messages-withRSC/csharp** — Wrong directory case (`images` → `Images`) and incorrect filename suffix
- **bot-formatting-cards/python** — `GaugeChart` → `GuageChart` to match actual filename
- **bot-type-ahead-search-adaptive-cards/python** — 4 images with incorrect `TypeaheadSearch/` prefix removed
- **bot-archive-groupchat-messages/python** — `.png` → `.jpg` to match actual file extension
- **user-scope-web-application/nodejs** — Dot → comma in filename to match actual file
- **connector-todo-notification/csharp** — Removed incorrect `TeamsToDoAppConnector/` prefix

All 13 corrected paths verified to point to existing image files in the repository.

## Test plan

- [ ] Verify all fixed image references render correctly on GitHub
- [ ] Confirm no other image paths were inadvertently changed
