### PR TITLE
Remove deprecated packageName field from manifest.json files

### DIFF
--- a/samples/TeamsJS/app-sso/csharp/App SSO Sample/AppManifest_Hub/manifest.json
+++ b/samples/TeamsJS/app-sso/csharp/App SSO Sample/AppManifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.13",
   "version": "1.0.0",
   "id": "<<YOUR-MICROSOFT-APP-ID>>",
-  "packageName": "com.microsoft.teams.samples.AppSSO",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://<<DOMAIN-NAME>>",

--- a/samples/TeamsJS/app-task-module/nodejs/src/manifest.json
+++ b/samples/TeamsJS/app-task-module/nodejs/src/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.12",
   "version": "1.0.0",
   "id": "f195eed2-4336-4c33-a11b-a417dcaa8680",
-  "packageName": "com.microsoft.teams.taskmoduletester",
   "developer": {
     "name": "Bill Bliss",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/incoming-webhook/csharp/IncomingWebhook/Manifest_Hub/manifest.json
+++ b/samples/TeamsJS/incoming-webhook/csharp/IncomingWebhook/Manifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.13",
   "version": "1.0.1",
   "id": "{{Manifest-id}}",
-  "packageName": "com.teams.incomingwebhook",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/m365-actions-preview/nodejs/appManifest/manifest.json
+++ b/samples/TeamsJS/m365-actions-preview/nodejs/appManifest/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.5",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "developer": {
     "name": "M365 platform teams",
     "websiteUrl": "${{TAB_ENDPOINT}}",

--- a/samples/TeamsJS/meetings-share-to-stage-signing/csharp/Source/M365Agent/appPackage/manifest.json
+++ b/samples/TeamsJS/meetings-share-to-stage-signing/csharp/Source/M365Agent/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.2",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.meetingsigning",
   "developer": {
     "name": "Contoso",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/tab-channel-group-quickstart/csharp/Microsoft.Teams.Samples.TabChannelGroupQuickstart.Web/AppManifest_Hub/manifest.json
+++ b/samples/TeamsJS/tab-channel-group-quickstart/csharp/Microsoft.Teams.Samples.TabChannelGroupQuickstart.Web/AppManifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "<<Microsoft-App-Id>>",
-  "packageName": "com.contoso.TabChannelGroupQuickstart",
   "developer": {
     "name": "Contoso",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/tab-external-auth/nodejs/appPackage/manifest.json
+++ b/samples/TeamsJS/tab-external-auth/nodejs/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "{{GUID-ID}}",
-  "packageName": "com.microsoft.teams.tabexternalauth",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/tab-graph-toolkit/csharp/TabGraphToolkit/AppManifest_Hub/manifest.json
+++ b/samples/TeamsJS/tab-graph-toolkit/csharp/TabGraphToolkit/AppManifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "{{Microsoft-App-Id}}",
-  "packageName": "com.microsoft.teams.mgtteamstab",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/tab-meeting-auto-recording/csharp/M365Agent/appPackage/manifest.json
+++ b/samples/TeamsJS/tab-meeting-auto-recording/csharp/M365Agent/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.teams.meetingautorecording",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/tab-nested-auth/csharp/M365Agent/appPackage/manifest.json
+++ b/samples/TeamsJS/tab-nested-auth/csharp/M365Agent/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.teams.tabnestedauth",
   "developer": {
     "name": "Teams App, Inc.",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/tab-nested-auth/nodejs/appManifest/manifest.json
+++ b/samples/TeamsJS/tab-nested-auth/nodejs/appManifest/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.teams.tabnestedauth",
   "developer": {
     "name": "Teams App, Inc.",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/TeamsJS/tab-request-approval/csharp/M365Agent/appPackage/manifest.json
+++ b/samples/TeamsJS/tab-request-approval/csharp/M365Agent/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.tabrequestapproval",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.teams.com",

--- a/samples/app-complete-sample/csharp/AppCompleteSample/AppManifest_Hub/manifest.json
+++ b/samples/app-complete-sample/csharp/AppCompleteSample/AppManifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.5",
   "id": "{{Microsoft-App-Id}}",
-  "packageName": "com.skype.teams.samples.sampleapp",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/app-hello-world/csharp/Microsoft.Teams.Samples.HelloWorld.Web/AppManifest_Hub/manifest.json
+++ b/samples/app-hello-world/csharp/Microsoft.Teams.Samples.HelloWorld.Web/AppManifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "<<Microsoft-App-Id>>",
-  "packageName": "com.contoso.helloworld",
   "developer": {
     "name": "Contoso",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/app-localization/csharp/Localization/AppManifest_Hub/manifest.json
+++ b/samples/app-localization/csharp/Localization/AppManifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.1",
   "id": "<<Azure Application ID>>",
-  "packageName": "com.contoso.localization",
   "localizationInfo": {
     "defaultLanguageTag": "en-us",
     "additionalLanguages": [

--- a/samples/app-region-selection/python/appManifest/manifest.json
+++ b/samples/app-region-selection/python/appManifest/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.com.testapp",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/bot-configuration-app-auth/csharp/M365Agent/appPackage/manifest.json
+++ b/samples/bot-configuration-app-auth/csharp/M365Agent/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.botconfigurationauth",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/bot-configuration-app-auth/nodejs/appManifest/manifest.json
+++ b/samples/bot-configuration-app-auth/nodejs/appManifest/manifest.json
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.botconfigurationauth",
     "developer": {
       "name": "Microsoft",
       "websiteUrl": "https://www.microsoft.com",

--- a/samples/bot-configuration-app-auth/python/appManifest/manifest.json
+++ b/samples/bot-configuration-app-auth/python/appManifest/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.botconfigurationauth",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/bot-configuration-app/nodejs/appManifest/manifest.json
+++ b/samples/bot-configuration-app/nodejs/appManifest/manifest.json
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.botconfiguration",
     "developer": {
       "name": "Microsoft",
       "websiteUrl": "https://www.microsoft.com",

--- a/samples/bot-type-ahead-search-adaptive-cards/python/appManifest/manifest.json
+++ b/samples/bot-type-ahead-search-adaptive-cards/python/appManifest/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.typeaheadsearchcard",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/graph-chat-lifecycle/csharp/ChatLifecycle/AppManifest_Hub/manifest.json
+++ b/samples/graph-chat-lifecycle/csharp/ChatLifecycle/AppManifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.1",
   "id": "<<YOUR-MICROSOFT-APP-ID>>",
-  "packageName": "com.contoso.teamsauthsso",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/requirement-targeting-mutual-dependency/nodejs/appPackage/manifest.json
+++ b/samples/requirement-targeting-mutual-dependency/nodejs/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "developer": {
     "name": "Teams App, Inc.",
     "websiteUrl": "https://www.example.com",

--- a/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/OneWay_ME_DependsOn_Bot/manifest.json
+++ b/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/OneWay_ME_DependsOn_Bot/manifest.json
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/OneWay_Tab_DependsOn_Bot/manifest.json
+++ b/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/OneWay_Tab_DependsOn_Bot/manifest.json
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/StaticTab_With_DialogURL/manifest.json
+++ b/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/StaticTab_With_DialogURL/manifest.json
@@ -4,7 +4,6 @@
     "version": "1.0.0",
 
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name": "Teams App, Inc.",
         "websiteUrl": "https://www.example.com",

--- a/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/manifest.json
+++ b/samples/requirement-targeting-oneway-dependency/nodejs/appPackage/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "devPreview",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.extension",
   "developer": {
     "name": "Teams App, Inc.",
     "websiteUrl": "https://www.example.com",

--- a/samples/tab-add-in-combined/nodejs/appManifest/manifest.json
+++ b/samples/tab-add-in-combined/nodejs/appManifest/manifest.json
@@ -3,7 +3,6 @@
     "manifestVersion": "devPreview",
     "version": "1.0.0",
     "id": "${{TEAMS_APP_ID}}",
-    "packageName": "com.microsoft.teams.extension",
     "developer": {
         "name":  "OP Developer Content Team",
         "websiteUrl": "${{TAB_ENDPOINT}}",

--- a/samples/tab-deeplink/python/appManifest/manifest.json
+++ b/samples/tab-deeplink/python/appManifest/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.deeplinkbot",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/tab-personal/mvc-csharp/Manifest_Hub/manifest.json
+++ b/samples/tab-personal/mvc-csharp/Manifest_Hub/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.19",
   "id": "<<Guid>>",
   "version": "1.0.0",
-  "packageName": "com.custom.tab",
   "developer": {
     "name": "Contoso",
     "websiteUrl": "https://www.microsoft.com",

--- a/samples/tab-stage-view/nodejs/appManifest/manifest.json
+++ b/samples/tab-stage-view/nodejs/appManifest/manifest.json
@@ -3,7 +3,6 @@
   "manifestVersion": "1.16",
   "version": "1.0.0",
   "id": "${{TEAMS_APP_ID}}",
-  "packageName": "com.microsoft.teams.tabstageview",
   "developer": {
     "name": "Microsoft",
     "websiteUrl": "https://www.microsoft.com",


### PR DESCRIPTION
## Summary

Removes the deprecated `packageName` property from 31 sample `manifest.json` files. This field was deprecated in the Teams app manifest schema and is no longer required or used by the Teams platform.

Keeping it in sample code causes confusion for developers who reference these samples, as they may assume the field is still required.

### Files changed
31 `manifest.json` files across samples including `tab-stage-view`, `tab-personal`, `tab-deeplink`, `bot-configuration-app`, `app-hello-world`, `graph-chat-lifecycle`, `requirement-targeting`, and more.

## Test plan

- [ ] Verify manifest files remain valid JSON after removal
- [ ] Confirm no other fields were affected
