### PR TITLE
Fix broken relative links in sample READMEs

### DIFF
--- a/samples/TeamsJS/meetings-stage-view/nodejs/Readme.md
+++ b/samples/TeamsJS/meetings-stage-view/nodejs/Readme.md
@@ -131,11 +131,11 @@ For reference please check [Share app content to stage API](https://docs.microso
 3) Search the uploaded app and copy the `App ID`
 ![Admin Center](Images/adminCenter.png)
 
-4) Navigate to `samples/TeamsJS/samples/TeamsJS/meetings-stage-view/nodejs/ClientApp/src/components/app-in-meeting.jsx`
+4) Navigate to `samples/TeamsJS/meetings-stage-view/nodejs/ClientApp/src/components/app-in-meeting.jsx`
 
 5) On line 74, replace `<<App id>>` with `Id` obtained in step 3.
 
-6) Navigate to `samples/TeamsJS/samples/TeamsJS/meetings-stage-view/nodejs/ClientApp/src/components/share-to-meeting.jsx`
+6) Navigate to `samples/TeamsJS/meetings-stage-view/nodejs/ClientApp/src/components/share-to-meeting.jsx`
 
 7) On line 25, replace `<Application-Base-URL>` with your application's base url whrre app is running. E.g. if you are using ngrok it would be something like `https://1234.ngrok-free.app` and if you are using dev tunnels, your URL will be like: https://12345.devtunnels.ms.
 

--- a/samples/TeamsJS/meetings-stage-view/python/README.md
+++ b/samples/TeamsJS/meetings-stage-view/python/README.md
@@ -138,11 +138,11 @@ For reference please check [Share app content to stage API](https://docs.microso
 3) Search the uploaded app and copy the `App ID`
 ![Admin Center](Images/adminCenter.png)
 
-4) Navigate to `samples/TeamsJS/samples/TeamsJS/meetings-stage-view/python/ClientApp/src/components/app-in-meeting.jsx`
+4) Navigate to `samples/TeamsJS/meetings-stage-view/python/ClientApp/src/components/app-in-meeting.jsx`
 
 5) Replace `<<App id>>` with `Id` obtained in step 3.
 
-6) Navigate to `samples/TeamsJS/samples/TeamsJS/meetings-stage-view/python/ClientApp/src/components/share-to-meeting.jsx`
+6) Navigate to `samples/TeamsJS/meetings-stage-view/python/ClientApp/src/components/share-to-meeting.jsx`
 
 7) Replace `<Application-Base-URL>` with your application's base url where app is running. E.g. if you are using ngrok it would be something like `https://1234.ngrok-free.app` and if you are using dev tunnels, your URL will be like: https://12345.devtunnels.ms.
 

--- a/samples/TeamsJS/tab-people-picker/csharp/README.md
+++ b/samples/TeamsJS/tab-people-picker/csharp/README.md
@@ -102,7 +102,7 @@ The simplest way to run this sample in Teams is to use Microsoft 365 Agents Tool
     ```
 - Run the bot from a terminal or from Visual Studio:
 
-  - From a terminal, navigate to `samples/TeamsJS/samples/TeamsJS/tab-people-picker/csharp`
+  - From a terminal, navigate to `samples/TeamsJS/tab-people-picker/csharp`
 
   ```bash
   # run the bot

--- a/samples/app-HR-talent/csharp/README.md
+++ b/samples/app-HR-talent/csharp/README.md
@@ -28,7 +28,7 @@ The HR Talent Management App is designed to simulate a comprehensive recruitment
 ## Try it yourself - experience the App in your Microsoft Teams client
 Please find below demo manifest which is deployed on Microsoft Azure and you can try it yourself by uploading the app manifest (.zip file link below) to your teams and/or as a personal app. (Uploading must be enabled for your tenant, [see steps here](https://docs.microsoft.com/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant#enable-custom-teams-apps-and-turn-on-custom-app-uploading)).
 
-**App HR Talent:** [Manifest](/samples/app-HR-talent/csharp/\src\demo-manifest\bot-task-module.zip)
+**App HR Talent:** [Manifest](/samples/app-HR-talent/csharp/src/demo-manifest/TeamsTalentMgmt.zip)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary

Fixes broken relative links in 4 sample READMEs:

- **meetings-stage-view/nodejs** — Removed duplicate `samples/TeamsJS/` prefix from 2 navigation paths (caused by TeamsJS folder reorganization)
- **meetings-stage-view/python** — Same duplicate prefix fix for 2 navigation paths
- **tab-people-picker/csharp** — Same duplicate prefix fix for 1 navigation path
- **app-HR-talent/csharp** — Fixed backslash path separators and corrected zip filename from `bot-task-module.zip` to `TeamsTalentMgmt.zip`

All corrected paths verified to point to existing files and directories.

## Test plan

- [ ] Verify corrected paths resolve to existing files on GitHub
- [ ] Confirm demo-manifest zip link downloads correctly
