### PR TITLE
Fix broken links in msteams-application-resourcehub README

### DIFF
--- a/samples/TeamsJS/msteams-application-resourcehub/README.md
+++ b/samples/TeamsJS/msteams-application-resourcehub/README.md
@@ -21,11 +21,11 @@ Resource Hub is an innovative solution crafted to enhance the Microsoft Teams ex
 Show users Art of Possible in Teams
 
 ## Quick links
-[Solution Overview](/samples/msteams-application-resourcehub/Documentation/SolutionOverview.md)
+[Solution Overview](/samples/TeamsJS/msteams-application-resourcehub/Documentation/SolutionOverview.md)
 
-[Deployment Guide](/samples/msteams-application-resourcehub/Documentation/DeploymentGuide.md)
+[Deployment Guide](/samples/TeamsJS/msteams-application-resourcehub/Documentation/DeploymentGuide.md)
 
-[App Installation Guide](/samples/msteams-application-resourcehub/Documentation/InstallationGuide.md)
+[App Installation Guide](/samples/TeamsJS/msteams-application-resourcehub/Documentation/InstallationGuide.md)
 
 Teams’ app capabilities included are – 
 1.	Custom Bing search
@@ -103,7 +103,7 @@ By filling in the feedback using item will be able to capture the item ID as wel
 
 Getting started feedback form: two feedback forms available
 1. Proactive feedback form: on completion of a learning path on achieving 100% our feedback form will pop up to capture user feedback as overall learning path
-2. Reactive feedback form: a feedback form is available to user where they can provide feedback on the learning path, and it is available throughout the completion of learning path   ## ![FeedbackOnLearningPath](Documentation/FeedbackOnLearningPath.png
+2. Reactive feedback form: a feedback form is available to user where they can provide feedback on the learning path, and it is available throughout the completion of learning path   ## ![FeedbackOnLearningPath](Documentation/FeedbackOnLearningPath.png)
 #New Tag
 When admin adds a new item under Essentials for you section of the application the item will be tagged as new for 24 hours
  


### PR DESCRIPTION
## Summary

Fixes broken links in the Resource Hub sample README after the TeamsJS folder reorganization:

- **3 documentation links** - Added missing `TeamsJS/` prefix to Solution Overview, Deployment Guide, and Installation Guide links
- **1 broken image** - Fixed missing closing parenthesis on `FeedbackOnLearningPath.png` reference

## Test plan

- [ ] Verify Solution Overview, Deployment Guide, and Installation Guide links resolve on GitHub
- [ ] Verify FeedbackOnLearningPath image renders correctly
