### PR TITLE
fix(bot-proactive-messaging-teamsfx/nodejs): use SingleTenant bot to fix InvalidBotCreationData arm/deploy failure

### DIFF
--- a/samples/bot-proactive-messaging-teamsfx/nodejs/bot/index.js
+++ b/samples/bot-proactive-messaging-teamsfx/nodejs/bot/index.js
@@ -12,7 +12,8 @@ const { TeamsBot } = require("./teamsBot");
 const botFrameworkAuthentication = new ConfigurationBotFrameworkAuthentication({
     MicrosoftAppId: process.env.BOT_ID,
     MicrosoftAppPassword: process.env.BOT_PASSWORD,
-    MicrosoftAppTenantId: process.env.TEAMS_APP_TENANT_ID
+    MicrosoftAppType: process.env.MicrosoftAppType || "SingleTenant",
+    MicrosoftAppTenantId: process.env.MicrosoftAppTenantId || process.env.TEAMS_APP_TENANT_ID
 });
 
 // Create CloudAdapter

--- a/samples/bot-proactive-messaging-teamsfx/nodejs/templates/azure/provision/bot.bicep
+++ b/samples/bot-proactive-messaging-teamsfx/nodejs/templates/azure/provision/bot.bicep
@@ -4,6 +4,7 @@ param userAssignedIdentityId string
 
 var resourceBaseName = provisionParameters.resourceBaseName
 var botAadAppClientId = provisionParameters['botAadAppClientId'] // Read AAD app client id for Azure Bot Service from parameters
+var botAadAppClientSecret = provisionParameters['botAadAppClientSecret'] // Read AAD app client secret for Azure Bot Service from parameters
 var botServiceName = contains(provisionParameters, 'botServiceName') ? provisionParameters['botServiceName'] : '${resourceBaseName}' // Try to read name for Azure Bot Service from parameters
 var botServiceSku = contains(provisionParameters, 'botServiceSku') ? provisionParameters['botServiceSku'] : 'F0' // Try to read SKU for Azure Bot Service from parameters
 var botDisplayName = contains(provisionParameters, 'botDisplayName') ? provisionParameters['botDisplayName'] : '${resourceBaseName}' // Try to read display name for Azure Bot Service from parameters
@@ -20,6 +21,8 @@ resource botService 'Microsoft.BotService/botServices@2021-03-01' = {
     displayName: botDisplayName
     endpoint: uri('https://${webApp.properties.defaultHostName}', '/api/messages')
     msaAppId: botAadAppClientId
+    msaAppType: 'SingleTenant' // Multitenant bot creation is deprecated, use SingleTenant
+    msaAppTenantId: tenant().tenantId
   }
   sku: {
     name: botServiceSku // You can follow https://aka.ms/teamsfx-bicep-add-param-tutorial to add botServiceSku property to provisionParameters to override the default value "F0".
@@ -63,6 +66,26 @@ resource webApp 'Microsoft.Web/sites@2021-02-01' = {
         {
           name: 'WEBSITE_NODE_DEFAULT_VERSION'
           value: '~18' // Set NodeJS version to 18.x for your site
+        }
+        {
+          name: 'BOT_ID'
+          value: botAadAppClientId
+        }
+        {
+          name: 'BOT_PASSWORD'
+          value: botAadAppClientSecret
+        }
+        {
+          name: 'TEAMS_APP_TENANT_ID'
+          value: tenant().tenantId
+        }
+        {
+          name: 'MicrosoftAppType'
+          value: 'SingleTenant'
+        }
+        {
+          name: 'MicrosoftAppTenantId'
+          value: tenant().tenantId
         }
       ]
     }


### PR DESCRIPTION
## Summary

Fixes the `arm/deploy` failure when provisioning `samples/bot-proactive-messaging-teamsfx/nodejs`:

```
(×) Error: arm/deploy failed.
{
  "provisionResources": {
    "botProvision": {
      "proactivemdev...": {
        "code": "InvalidBotCreationData",
        "message": "Multitenant bot creation is deprecated. Please use SingleTenant or UserAssignedMSI"
      }
    }
  }
}
```

Azure Bot Service no longer accepts MultiTenant bot creation. The bot resource in `templates/azure/provision/bot.bicep` did not specify `msaAppType`, so it defaulted to the deprecated `MultiTenant`, causing provisioning to fail.

## Changes

- `templates/azure/provision/bot.bicep`
  - Set `msaAppType: 'SingleTenant'` and `msaAppTenantId: tenant().tenantId` on the `Microsoft.BotService/botServices` resource.
  - Read `botAadAppClientSecret` from `provisionParameters` (already passed in via `azure.parameters.dev.json`).
  - Add the following App Service `appSettings` so the deployed bot runs as SingleTenant and has the credentials it needs at runtime:
    - `BOT_ID`, `BOT_PASSWORD`, `TEAMS_APP_TENANT_ID`
    - `MicrosoftAppType=SingleTenant`, `MicrosoftAppTenantId=tenant().tenantId`
- `bot/index.js`
  - Forward `MicrosoftAppType` (defaults to `SingleTenant`) and `MicrosoftAppTenantId` to `ConfigurationBotFrameworkAuthentication`.

## Verification

- `m365agents provision` (cloud `dev` env) — bot resource is now created successfully.
- `m365agents deploy` — App Service starts with single-tenant configuration; messaging endpoint responds.
- `m365agents.local.yml` was already SingleTenant; no change needed for local debug.

## Sample affected

`samples/bot-proactive-messaging-teamsfx/nodejs`
