### PR TITLE
fix(bot-proactive-messaging): use double underscore in ARM output env var names

### DIFF
--- a/samples/bot-proactive-messaging-teamsfx/nodejs/.vscode/tasks.json
+++ b/samples/bot-proactive-messaging-teamsfx/nodejs/.vscode/tasks.json
@@ -53,8 +53,8 @@
                         "access": "public",
                         "writeToEnvironmentFile": {
                             // Keep consistency with upgraded configuration.
-                            "endpoint": "PROVISIONOUTPUT_BOTOUTPUT_SITEENDPOINT",
-                            "domain": "PROVISIONOUTPUT_BOTOUTPUT_VALIDDOMAIN"
+                            "endpoint": "PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT",
+                            "domain": "PROVISIONOUTPUT__BOTOUTPUT__VALIDDOMAIN"
                         }
                     }
                 ],

--- a/samples/bot-proactive-messaging-teamsfx/nodejs/README.md
+++ b/samples/bot-proactive-messaging-teamsfx/nodejs/README.md
@@ -50,10 +50,10 @@ Please find below demo manifest which is deployed on Microsoft Azure and you can
   - Install [dev tunnel cli](https://aka.ms/teamsfx-install-dev-tunnel).
   - Login with your M365 Account using the command `devtunnel user login`.
   - Start your local tunnel service by running the command `devtunnel host -p 3978 --protocol http --allow-anonymous`.
-  - In the `env/.env.local` file, fill in the values for `PROVISIONOUTPUT_BOTOUTPUT_VALIDDOMAIN` and `PROVISIONOUTPUT_BOTOUTPUT_SITEENDPOINT` with your dev tunnel URL.
+  - In the `env/.env.local` file, fill in the values for `PROVISIONOUTPUT__BOTOUTPUT__VALIDDOMAIN` and `PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT` with your dev tunnel URL.
     ```
-    PROVISIONOUTPUT_BOTOUTPUT_VALIDDOMAIN=sample-id-3978.devtunnels.ms
-    PROVISIONOUTPUT_BOTOUTPUT_SITEENDPOINT=https://sample-id-3978.devtunnels.ms
+    PROVISIONOUTPUT__BOTOUTPUT__VALIDDOMAIN=sample-id-3978.devtunnels.ms
+    PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT=https://sample-id-3978.devtunnels.ms
     ```
   - Executing the command `atk provision --env local` in your project directory.
   - Executing the command `atk deploy --env local` in your project directory.

--- a/samples/bot-proactive-messaging-teamsfx/nodejs/appPackage/manifest.json
+++ b/samples/bot-proactive-messaging-teamsfx/nodejs/appPackage/manifest.json
@@ -71,6 +71,6 @@
     "messageTeamMembers"
   ],
   "validDomains": [
-    "${{PROVISIONOUTPUT_BOTOUTPUT_VALIDDOMAIN}}"
+    "${{PROVISIONOUTPUT__BOTOUTPUT__VALIDDOMAIN}}"
   ]
 }

--- a/samples/bot-proactive-messaging-teamsfx/nodejs/m365agents.local.yml
+++ b/samples/bot-proactive-messaging-teamsfx/nodejs/m365agents.local.yml
@@ -35,7 +35,7 @@ provision:
     with:
       botId: ${{BOT_ID}}
       name: ${{CONFIG_APPNAME_SHORT}}-bot
-      messagingEndpoint: ${{PROVISIONOUTPUT_BOTOUTPUT_SITEENDPOINT}}/api/messages
+      messagingEndpoint: ${{PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT}}/api/messages
       description: ""
       channels:
         - name: msteams
@@ -71,7 +71,7 @@ deploy:
     with:
       target: ./bot/.env.teamsfx.local
       envs:
-        INITIATE_LOGIN_ENDPOINT: ${{PROVISIONOUTPUT_BOTOUTPUT_SITEENDPOINT}}/auth-start.html
+        INITIATE_LOGIN_ENDPOINT: ${{PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT}}/auth-start.html
         M365_APPLICATION_ID_URI: api://botid-${{BOT_ID}}
 
   # Run npm command

--- a/samples/bot-proactive-messaging-teamsfx/nodejs/templates/azure/teamsFx/bot.bicep
+++ b/samples/bot-proactive-messaging-teamsfx/nodejs/templates/azure/teamsFx/bot.bicep
@@ -19,6 +19,6 @@ resource botWebAppSettings 'Microsoft.Web/sites/config@2021-02-01' = {
     BOT_ID: botId // ID of your bot
     BOT_PASSWORD: botAadAppClientSecret // Secret of your bot
     IDENTITY_ID: provisionOutputs.identityOutput.value.identityClientId // User assigned identity id, the identity is used to access other Azure resources
-    PROVISIONOUTPUT_BOTOUTPUT_SITEENDPOINT : provisionOutputs.botOutput.value.siteEndpoint // Site endpoint of AAD application
+    PROVISIONOUTPUT__BOTOUTPUT__SITEENDPOINT : provisionOutputs.botOutput.value.siteEndpoint // Site endpoint of AAD application
   }, currentAppSettings)
 }


### PR DESCRIPTION
## Problem

The arm/deploy action has used __ (double underscore) as the separator for nested Bicep output env var names since its introduction in Oct 2022. The bot-proactive-messaging-teamsfx sample was created during the v3 Alpha period and uses single underscore (PROVISIONOUTPUT_BOTOUTPUT_VALIDDOMAIN), which causes:

- **Cloud provision**: validDomains in the manifest is empty/undefined (env var not found)
- **Cloud provision**: azureAppService/zipDeploy fails because PROVISIONOUTPUT__BOTOUTPUT__BOTWEBAPPRESOURCEIDis correct but manifest uses wrong name
- **Local debug**: dev tunnel writes single-underscore vars but manifest reads double-underscore (inconsistent)

Note: m365agents.yml already correctly uses double underscore for PROVISIONOUTPUT__BOTOUTPUT__BOTWEBAPPRESOURCEID in the deploy section, confirming this is the expected format.

## Fix

Replace all single-underscore PROVISIONOUTPUT_BOTOUTPUT_* references with double-underscore PROVISIONOUTPUT__BOTOUTPUT__*:

- appPackage/manifest.json
- m365agents.local.yml(2 occurrences)
- .vscode/tasks.json (writeToEnvironmentFile keys for local tunnel)
- 	emplates/azure/teamsFx/bot.bicep (Azure App Service app setting name)
- README.md (documentation)