### PR TITLE
[teams sdk] relax python upper bound and move provisioning to CLI

### DIFF
--- a/samples/TeamsSDK/bot-ai-messages/README.md
+++ b/samples/TeamsSDK/bot-ai-messages/README.md
@@ -39,9 +39,9 @@ You can run these samples locally in the Teams Client after you have provisioned
 
 To run these samples in the Teams Client, you need to provision your app in an M365 tenant and configure the app to your DevTunnels URL.
 
-1. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
-2. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
-3. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
+1. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
+2. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
+3. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
 
 ### Configure DevTunnels
 

--- a/samples/TeamsSDK/bot-ai-messages/README.md
+++ b/samples/TeamsSDK/bot-ai-messages/README.md
@@ -83,6 +83,8 @@ This single command creates a Microsoft Entra app registration, registers a Team
 
 Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive these CLI steps from natural language - your assistant runs the right commands, manages credentials, and guides you through bot registration end-to-end.
+
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
@@ -93,4 +95,5 @@ Once provisioning completes, start your bot - the sample will pick up the creden
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language
 - [Bot messages with AI-generated content](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bot-messages-ai-generated-content) - Overview of AI-generated content features in bot messages

--- a/samples/TeamsSDK/bot-ai-messages/README.md
+++ b/samples/TeamsSDK/bot-ai-messages/README.md
@@ -12,15 +12,16 @@ This sample demonstrates a Teams bot that showcases AI message formatting featur
 - [Interaction with Bot](#interaction-with-bot)
 - [Sample Implementations](#sample-implementations)
 - [How to run these samples](#how-to-run-these-samples)
-- [Run in the Teams Client](#run-in-the-teams-client)
-- [Configure the new project to use the new Teams Bot Application](#configure-the-new-project-to-use-the-new-teams-bot-application)
-- [Pro Tip: Read the configuration settings using the Azure CLI](#pro-tip-read-the-configuration-settings-using-the-azure-cli)
+  - [Run in the Teams Client](#run-in-the-teams-client)
+    - [Configure DevTunnels](#configure-devtunnels)
+  - [Provision with the Teams Developer CLI](#provision-with-the-teams-developer-cli)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
 ## Interaction with Bot
 
 ![Bot AI Messages](bot-ai-messages.gif)
+
 
 ## Sample Implementations
 
@@ -32,108 +33,64 @@ This sample demonstrates a Teams bot that showcases AI message formatting featur
 
 # How to run these samples
 
-You can run these samples locally using:
-
-1. In the Teams Client after you have provisioned the Teams Application and configured the application with your local DevTunnels URL.
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project's environment file, and started the bot against a public DevTunnels URL.
 
 ## Run in the Teams Client
 
-To run these samples in the Teams Client, you need to provision your app in a M365 Tenant, and configure the app to your DevTunnels URL.
+To run these samples in the Teams Client, you need to provision your app in an M365 tenant and configure the app to your DevTunnels URL.
 
-1. Install the tool DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-2. Get Access to a M365 Developer Tenant https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started
-3. Create a Teams App with the Bot Feature in the Teams Developer Portal (in your tenant) https://dev.teams.microsoft.com
+1. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
+2. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
+3. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
 
 ### Configure DevTunnels
 
-Create a persistent tunnel for the port 3978 with anonymous access
+Create a persistent tunnel for port 3978 with anonymous access:
 
-```
-devtunnel create -a my-tunnel  
-devtunnel port create -p 3978  my-tunnel 
-devtunnel host  my-tunnel
+```bash
+devtunnel create -a my-tunnel
+devtunnel port create -p 3978 my-tunnel
+devtunnel host my-tunnel
 ```
 
 Take note of the URL shown after *Connect via browser:*
 
-### Provisioning the Teams Application
+## Provision with the Teams Developer CLI
 
-Navigate to the Teams Developer Portal http://dev.teams.microsoft.com
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project's environment file in a single command.
 
-#### Create a new Bot resource
+Sign in with your M365 account:
 
-1. Navigate to `Tools->Bot management`, and add a `New bot`
-1. In Configure, paste the Endpoint address from devtunnels and append `/api/messages`
-1. In Client secrets, create a new secret and save it for later
-
-> Note. If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
-
-#### Create a new Teams App
-
-1. Navigate to `Apps` and create a `New App`
-1. Fill the required values in Basic information (short and long name, short and long description and App URLs)
-1. In `App features->Bot` select the bot you created previously
-1. Select `Preview in Teams`
-
-> Note. When using an Azure Bot resource, provide the ClientID instead of selecting an existing bot.
-
-## Configure the new project to use the new Teams Bot Application
-
-For NodeJS and Python you will need a `.env` file with the next fields
-
-```
-TENANT_ID=
-CLIENT_ID=
-CLIENT_SECRET=
+```bash
+teams login
 ```
 
-For dotnet you need to add these values to `appsettings.json` or `launchSettings.json` using the next syntax.
+From the language-specific sample directory you want to run, provision the app and credentials.
 
-appsettings.json
+For Node.js and Python (`nodejs/<sample>` or `python/<sample>`):
 
-```json
-"urls" : "http://localhost:3978",
-"Teams": {
-    "ClientID": "",
-    "ClientSecret": "",
-    "TenantId": ""
-  },
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env .env
 ```
 
-Or to use Env Vars from the profile defined in `launchSettings.json` (using the Environment Configuration Provider)
+For .NET (`dotnet/<sample>`):
 
-```json
- "teamsbot": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:3978",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Teams__TenantId": "YOUR_TenantId",
-        "Teams__ClientID": "YOUR_ClientId",
-        "Teams__ClientSecret": "YOUR_ClientSecret"
-      }
-    }
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env appsettings.json
 ```
 
-## Pro Tip: Read the configuration settings using the Azure CLI
+This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your DevTunnels endpoint, generates and uploads the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
 
-To obtain the TenantId, ClientId and ClientSecret you can use the Azure CLI with:
-
-> Note. If you don't have access to an Azure Subscription you can still use the Azure CLI, make sure you login with `az login --allow-no-subscription`
-
-```
-az ad app credential reset --id $appId
-```
+Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
-- Ensure your .env or appsettings file is setup correctly.
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors (not available in Teams Developer Portal).
+- Ensure your `.env` or `appsettings.json` file is set up correctly.
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors.
 
 ## Further Reading
- 
+
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
-- [Bot messages with AI-generated content](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bot-messages-ai-generated-content) - Overview of AI-generated content features in bot messages 
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
+- [Bot messages with AI-generated content](https://learn.microsoft.com/en-us/microsoftteams/platform/bots/how-to/bot-messages-ai-generated-content) - Overview of AI-generated content features in bot messages

--- a/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/README.md
+++ b/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to enhance AI-generated bot messages for Microsoft 
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample

--- a/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/README.md
+++ b/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to enhance AI-generated bot messages for Microsoft 
 
 ## Prerequisites
 
-- [Python >=3.12, <3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample

--- a/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/pyproject.toml
+++ b/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-ai-messages"
 version = "0.1.0"
 description = "Bot AI messaging sample that demonstrates how to enhance AI-generated bot messages"
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "microsoft-teams-apps==2.0.0",
     "microsoft-teams-api==2.0.0",

--- a/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/pyproject.toml
+++ b/samples/TeamsSDK/bot-ai-messages/python/bot-ai-messages/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-ai-messages"
 version = "0.1.0"
 description = "Bot AI messaging sample that demonstrates how to enhance AI-generated bot messages"
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "microsoft-teams-apps==2.0.0",
     "microsoft-teams-api==2.0.0",

--- a/samples/TeamsSDK/bot-attachments/README.md
+++ b/samples/TeamsSDK/bot-attachments/README.md
@@ -83,6 +83,8 @@ This single command creates a Microsoft Entra app registration, registers a Team
 
 Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive these CLI steps from natural language - your assistant runs the right commands, manages credentials, and guides you through bot registration end-to-end.
+
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
@@ -93,3 +95,4 @@ Once provisioning completes, start your bot - the sample will pick up the creden
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language

--- a/samples/TeamsSDK/bot-attachments/README.md
+++ b/samples/TeamsSDK/bot-attachments/README.md
@@ -8,8 +8,8 @@ This sample demonstrates how to handle file downloads, uploads, and consent card
 - [Sample Implementations](#sample-implementations)
 - [How to run these samples](#how-to-run-these-samples)
   - [Run in the Teams Client](#run-in-the-teams-client)
-- [Configure the new project to use the new Teams Bot Application](#configure-the-new-project-to-use-the-new-teams-bot-application)
-- [Pro Tip: Read the configuration settings using the Azure CLI](#pro-tip-read-the-configuration-settings-using-the-azure-cli)
+    - [Configure DevTunnels](#configure-devtunnels)
+  - [Provision with the Teams Developer CLI](#provision-with-the-teams-developer-cli)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
@@ -33,109 +33,63 @@ The bot supports the following file management functionalities:
 
 # How to run these samples
 
-You can run these samples locally using:
-
-1. In the Teams Client after you have provisioned the Teams Application and configured the application with your local DevTunnels URL.
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project's environment file, and started the bot against a public DevTunnels URL.
 
 ## Run in the Teams Client
 
-To run these samples in the Teams Client, you need to provision your app in a M365 Tenant, and configure the app to your DevTunnels URL.
+To run these samples in the Teams Client, you need to provision your app in an M365 tenant and configure the app to your DevTunnels URL.
 
-1. Install the tool DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-2. Get Access to a M365 Developer Tenant https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started
-3. Create a Teams App with the Bot Feature in the Teams Developer Portal (in your tenant) https://dev.teams.microsoft.com
+1. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
+2. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
+3. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
 
 ### Configure DevTunnels
 
-Create a persistent tunnel for the port 3978 with anonymous access
+Create a persistent tunnel for port 3978 with anonymous access:
 
-```
-devtunnel create -a my-tunnel  
-devtunnel port create -p 3978  my-tunnel 
-devtunnel host  my-tunnel
+```bash
+devtunnel create -a my-tunnel
+devtunnel port create -p 3978 my-tunnel
+devtunnel host my-tunnel
 ```
 
 Take note of the URL shown after *Connect via browser:*
 
-### Provisioning the Teams Application
+## Provision with the Teams Developer CLI
 
-Navigate to the Teams Developer Portal http://dev.teams.microsoft.com
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project's environment file in a single command.
 
-#### Create a new Bot resource
+Sign in with your M365 account:
 
-1. Navigate to `Tools->Bot management`, and add a `New bot`
-1. In Configure, paste the Endpoint address from devtunnels and append `/api/messages`
-1. In Client secrets, create a new secret and save it for later
-
-> Note. If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
-
-#### Create a new Teams App
-
-1. Navigate to `Apps` and create a `New App`
-1. Fill the required values in Basic information (short and long name, short and long description and App URLs)
-1. In `App features->Bot` select the bot you created previously
-1. Select `Preview in Teams`
-
-> Note. When using an Azure Bot resource, provide the ClientID instead of selecting an existing bot.
-
-## Configure the new project to use the new Teams Bot Application
-
-For NodeJS and Python you will need a `.env` file with the next fields
-
-```
-TENANT_ID=
-CLIENT_ID=
-CLIENT_SECRET=
+```bash
+teams login
 ```
 
-For dotnet you need to add these values to `appsettings.json` or `launchSettings.json` using the next syntax.
+From the language-specific sample directory you want to run, provision the app and credentials.
 
-appsettings.json
+For Node.js and Python (`nodejs/<sample>` or `python/<sample>`):
 
-
-```json
-"urls" : "http://localhost:3978",
-"Teams": {
-    "ClientId": "",
-    "ClientSecret": "",
-    "TenantId": ""
-  },
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env .env
 ```
 
-Or to use Env Vars from the profile defined in `launchSettings.json` (using the Environment Configuration Provider)
+For .NET (`dotnet/<sample>`):
 
-```json
- "teamsbot": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:3978",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Teams__TenantId": "YOUR_TenantId",
-        "Teams__ClientId": "YOUR_ClientId",
-        "Teams__ClientSecret": "YOUR_ClientSecret"
-      }
-    }
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env appsettings.json
 ```
 
-## Pro Tip: Read the configuration settings using the Azure CLI
+This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your DevTunnels endpoint, generates and uploads the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
 
-To obtain the TenantId, ClientId and ClientSecret you can use the Azure CLI with:
-
-> Note. If you don't have access to an Azure Subscription you can still use the Azure CLI, make sure you login with `az login --allow-no-subscription` 
-
-```
-az ad app credential reset --id $appId
-```
+Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
-- Ensure your .env or appsettings file is setup correctly.
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors (not available in Teams Developer Portal).
-
+- Ensure your `.env` or `appsettings.json` file is set up correctly.
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors.
 
 ## Further Reading
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)

--- a/samples/TeamsSDK/bot-attachments/nodejs/bot-attachments/README.md
+++ b/samples/TeamsSDK/bot-attachments/nodejs/bot-attachments/README.md
@@ -25,4 +25,4 @@ This sample demonstrates how to upload files in Microsoft Teams using a bot buil
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-attachments/python/bot-attachments/README.md
+++ b/samples/TeamsSDK/bot-attachments/python/bot-attachments/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to upload files in Microsoft Teams using a bot buil
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installation/)
 - [uv](https://docs.astral.sh/uv/)
 

--- a/samples/TeamsSDK/bot-attachments/python/bot-attachments/README.md
+++ b/samples/TeamsSDK/bot-attachments/python/bot-attachments/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to upload files in Microsoft Teams using a bot buil
 
 ## Prerequisites
 
-- [Python >=3.12,<3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installation/)
 - [uv](https://docs.astral.sh/uv/)
 
@@ -35,4 +35,4 @@ python main.py
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-attachments/python/bot-attachments/pyproject.toml
+++ b/samples/TeamsSDK/bot-attachments/python/bot-attachments/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-attachments"
 version = "0.1.0"
 description = "Bot Attachments sample"
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "python-dotenv>=1.0.0",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-attachments/python/bot-attachments/pyproject.toml
+++ b/samples/TeamsSDK/bot-attachments/python/bot-attachments/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-attachments"
 version = "0.1.0"
 description = "Bot Attachments sample"
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "python-dotenv>=1.0.0",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/README.md
@@ -240,7 +240,7 @@ python main.py
 
 ### Option 2: Teams Developer CLI
 
-The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions the Microsoft Entra app, Azure Bot resource, and Teams app manifest, and writes the credentials into your project. The OAuth/SSO specifics (redirect URI, Application ID URI, manifest `webApplicationInfo` / `validDomains`, and the OAuth connection on the Azure Bot resource) are not yet automated by the CLI and are configured manually after provisioning.
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions the Microsoft Entra app, Azure Bot resource, and Teams app manifest, and writes the credentials into your project. `teams app create` also seeds the manifest's `validDomains` with `*.botframework.com` and your endpoint domain. A few SSO-specific pieces still need manual configuration after provisioning: the AAD app's Bot Framework redirect URI and Application ID URI, the manifest's `webApplicationInfo` (settable via `teams app update --web-app-info-id --web-app-info-resource` — no manual JSON edit needed), and the OAuth connection on the Azure Bot resource.
 
 > **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive the CLI provisioning **and** the manual SSO/OAuth configuration steps below from natural language - the skill includes dedicated SSO setup guidance and can walk you through the portal steps the CLI does not yet automate.
 

--- a/samples/TeamsSDK/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/README.md
@@ -297,10 +297,28 @@ Open the app registration the CLI just created in the [Microsoft Entra ID - App 
 - Set the **Redirect URI** to `https://token.botframework.com/.auth/web/redirect`
 - Click **Configure**
 
+Or via the [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (run `az login` first):
+
+```bash
+az ad app update --id <Application (client) ID> \
+  --web-redirect-uris https://token.botframework.com/.auth/web/redirect
+```
+
+> **Note**: `--web-redirect-uris` **replaces** all existing web redirect URIs on the AAD app. For a fresh app registration created by `teams app create` this is safe; if you've already added other redirect URIs, include them all in the command.
+
 **B) Expose an Application ID URI:**
 
 - Under **Manage**, navigate to **Expose an API**
 - Click **Add** next to **Application ID URI** and set it to `api://botid-<Application (client) ID>` (the value used in `webApplicationInfo.resource` in the manifest)
+
+Or via the Azure CLI:
+
+```bash
+az ad app update --id <Application (client) ID> \
+  --identifier-uris api://botid-<Application (client) ID>
+```
+
+> **Note**: `--identifier-uris` **replaces** all existing identifier URIs on the AAD app. For a fresh app registration created by `teams app create` this is safe.
 
 **C) Verify Graph permissions:**
 

--- a/samples/TeamsSDK/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/README.md
@@ -7,7 +7,7 @@ This sample demonstrates how to implement Single Sign-On (SSO) authentication fo
 
 > **IMPORTANT**: The manifest file in this app requires the following fields for the Teams SDK OAuth flow:
 > - **`validDomains`**: Must include `"token.botframework.com"` to allow the OAuth token flow.
-> - **`webApplicationInfo`**: Must be configured with your Azure AD app''s `id` (App Id / Client ID) and `resource` (e.g., `api://botid-{AppId}`). This is required for SSO authentication to work in Teams.
+> - **`webApplicationInfo`**: Must be configured with your Azure AD app's `id` (App Id / Client ID) and `resource` (e.g., `api://botid-{AppId}`). This is required for SSO authentication to work in Teams.
 > Both fields must be present in any bot that uses Teams SSO or OAuth authentication.
 
 ## Table of Contents
@@ -17,6 +17,8 @@ This sample demonstrates how to implement Single Sign-On (SSO) authentication fo
 - [Microsoft Graph Integration](#microsoft-graph-integration)
 - [Prerequisites](#prerequisites)
 - [Setup Instructions](#setup-instructions)
+  - [Option 1: Manual Setup](#option-1-manual-setup)
+  - [Option 2: Teams Developer CLI](#option-2-teams-developer-cli)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
@@ -47,7 +49,7 @@ This sample demonstrates comprehensive Microsoft Graph API integration to access
 The bot leverages Microsoft Graph to:
 
 1. **User Profile Access**:
-   - Retrieves authenticated user''s profile information
+   - Retrieves authenticated user's profile information
    - Accesses user display name, email, job title, department, and office location
    - Uses delegated permissions on behalf of the signed-in user
 
@@ -56,7 +58,7 @@ The bot leverages Microsoft Graph to:
 This sample requires the following Microsoft Graph permissions:
 
 **Delegated Permissions** (user or admin consent required):
-- `User.Read` - Read the signed-in user''s profile
+- `User.Read` - Read the signed-in user's profile
 
 ### User Authentication Flow
 
@@ -73,7 +75,7 @@ The sample uses Azure AD SSO (Single Sign-On) with the Teams SDK OAuth flow:
 Teams SSO involves two types of consent:
 
 - **User consent**: On the first sign-in, the user is prompted to consent to the permissions (e.g., `User.Read`). After consent is granted, subsequent sign-ins are silent - no prompt is shown.
-- **Admin consent**: An organization''s administrator can pre-consent on behalf of all users in the tenant. If admin consent has been granted, individual users will not see a consent prompt.
+- **Admin consent**: An organization's administrator can pre-consent on behalf of all users in the tenant. If admin consent has been granted, individual users will not see a consent prompt.
 
 > **Note**: If you need to reset consent and re-trigger the consent prompt (e.g., for testing), you can do so by:
 > 1. Go to [My Apps](https://myapps.microsoft.com) -> find your app -> **Remove** it, or
@@ -82,7 +84,7 @@ Teams SSO involves two types of consent:
 
 ### Graph API Endpoints Used
 
-- `GET /me` - Get current user''s profile
+- `GET /me` - Get current user's profile
 
 ## Prerequisites
 
@@ -97,16 +99,157 @@ Teams SSO involves two types of consent:
 
 ## Setup Instructions
 
+### Option 1: Manual Setup
+
+#### 1. Setup for Bot SSO
+
+- Refer to [Bot SSO Setup document](BotSSOSetup.md)
+- Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
+- While registering the Azure bot, use `https://<your_tunnel_domain>/api/messages` as the messaging endpoint
+
+> NOTE: When you create your app registration in Azure portal, you will create a ClientID and ClientSecret - make sure you keep these for later.
+
+#### 2. Setup Local Tunnel
+
+Create a persistent tunnel for port 3978 with anonymous access so it can be reused across projects:
+
+```
+devtunnel create -a my-tunnel
+devtunnel port create -p 3978 my-tunnel
+devtunnel host my-tunnel
+```
+
+Take note of the URL shown after *Connect via browser:*
+
+#### 3. Register Azure AD Application
+
+Register a new application in the [Microsoft Entra ID – App Registrations](https://go.microsoft.com/fwlink/?linkid=2083908) portal.
+
+**A) Create New Registration:**
+- Select **New Registration** and on the *register an application page*, set following values:
+  - Set **name** to your app name
+  - Choose the **supported account types** (any account type will work)
+  - Leave **Redirect URI** empty
+  - Choose **Register**
+
+**B) Add Authentication Platform:**
+- Under **Manage**, navigate to **Authentication**
+- Click **Add a platform** and select **Web**
+- Set the **Redirect URI** to `https://token.botframework.com/.auth/web/redirect`
+- Click **Configure**
+
+**C) Save Application Details (skip if already done):**
+- On the overview page, copy and save the **Application (client) ID** and **Directory (tenant) ID**
+- You'll need these later when updating your Teams application manifest and configuration files
+
+**D) Create Client Secret:**
+- Under **Manage**, navigate to **Certificates & secrets**
+- In the **Client secrets** section, click on **+ New client secret**
+- Add a description (e.g., "Teams Bot Secret") and select an expiration period
+- Click **Add**
+- **Important**: Copy the client secret **Value** immediately and save it securely. You won't be able to see it again!
+
+**E) Configure API Permissions:**
+- Navigate to **API Permissions**
+- Click **Add a permission**
+- Select **Microsoft Graph** -> **Delegated permissions**:
+  - `User.Read` (enabled by default)
+- Click **Add permissions**
+- Click **Grant admin consent** to grant admin consent for the required permissions
+
+#### 4. Setup Code
+
+**Clone the repository:**
+
+```bash
+git clone https://github.com/OfficeDev/Microsoft-Teams-Samples.git
+```
+
+**Navigate to the sample directory:**
+
+```bash
+# For Node.js:
+cd samples/TeamsSDK/bot-auth-quickstart/nodejs/bot-auth-quickstart
+
+# For .NET:
+cd samples/TeamsSDK/bot-auth-quickstart/dotnet/bot-auth-quickstart
+
+# For Python:
+cd samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart
+```
+
+**Install dependencies:**
+
+For Node.js:
+```bash
+npm install
+```
+
+For .NET:
+```bash
+dotnet restore
+```
+
+For Python:
+```bash
+pip install -r requirements.txt
+```
+
+**Configure environment variables:**
+
+Update the configuration file (`.env`, `appsettings.json`, or `.env` depending on language) with the values from step 3 (Azure AD app registration):
+
+- `CLIENT_ID` - The Application (client) ID from step 3
+- `CLIENT_SECRET` - The client secret value from step 3C
+- `TENANT_ID` - Your Directory (tenant) ID from step 3 (required for SingleTenant)
+- `CONNECTION_NAME` - The name of your Azure Bot OAuth connection created in step 1
+
+#### 5. Setup Teams App
+
+Navigate to the Teams Developer Portal at https://dev.teams.microsoft.com
+
+**Create a new Bot resource:**
+1. Navigate to **Tools** -> **Bot management**, and add a **New bot**
+2. In **Configure**, paste the devtunnel endpoint URL and append `/api/messages`
+3. In **Client secrets**, create a new secret and save it for later
+
+> **Note**: If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
+
+**Create a new Teams App:**
+1. Navigate to **Apps** and create a **New App**
+2. Fill the required values in **Basic information** (short and long name, descriptions, and App URLs)
+3. In **App features** -> **Bot**, select the bot you created previously
+4. Select **Preview in Teams**
+
+#### 6. Start the Bot
+
+For Node.js:
+```bash
+npm start
+```
+
+For .NET:
+```bash
+dotnet run
+```
+
+For Python:
+```bash
+python main.py
+```
+
+### Option 2: Teams Developer CLI
+
 The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions the Microsoft Entra app, Azure Bot resource, and Teams app manifest, and writes the credentials into your project. The OAuth/SSO specifics (redirect URI, Application ID URI, manifest `webApplicationInfo` / `validDomains`, and the OAuth connection on the Azure Bot resource) are not yet automated by the CLI and are configured manually after provisioning.
 
-### 1. Install the Teams Developer CLI
+#### 1. Install the Teams Developer CLI
 
 ```bash
 npm install -g @microsoft/teams.cli
 teams login
 ```
 
-### 2. Setup Local Tunnel
+#### 2. Setup Local Tunnel
 
 Create a persistent tunnel for port 3978 with anonymous access so it can be reused across projects:
 
@@ -118,7 +261,7 @@ devtunnel host my-tunnel
 
 Take note of the URL shown after *Connect via browser:*.
 
-### 3. Provision the App with the Teams Developer CLI
+#### 3. Provision the App with the Teams Developer CLI
 
 From the language-specific sample directory you want to run, provision the Microsoft Entra app, Azure Bot resource, and manifest, and write credentials into your environment file. SSO requires an Azure-hosted bot, so the `--azure` flag is required:
 
@@ -142,7 +285,7 @@ teams app create --name "Bot Auth Quickstart" --azure \
 
 The command creates the Microsoft Entra app registration, an Azure Bot resource pointing at your tunnel endpoint, a Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified. Save the printed Teams app ID and Bot resource name for the next steps.
 
-### 4. Configure the AAD App for SSO
+#### 4. Configure the AAD App for SSO
 
 Open the app registration the CLI just created in the [Microsoft Entra ID - App Registrations](https://go.microsoft.com/fwlink/?linkid=2083908) portal.
 
@@ -165,7 +308,7 @@ Open the app registration the CLI just created in the [Microsoft Entra ID - App 
 
 For more SSO background, see [Bot SSO Setup document](BotSSOSetup.md).
 
-### 5. Configure the SSO Manifest Fields
+#### 5. Configure the SSO Manifest Fields
 
 Edit `appPackage/manifest.json` (or `appManifest/manifest.json`) and add the SSO-specific blocks:
 
@@ -187,13 +330,13 @@ teams app package
 teams app update <teamsAppId> --file appPackage/<package>.zip
 ```
 
-### 6. Create the OAuth Connection on the Azure Bot
+#### 6. Create the OAuth Connection on the Azure Bot
 
-In the Azure Portal, open the Azure Bot resource created by the CLI -> **Settings** -> **Configuration** -> **OAuth Connection Settings** and add a new connection. Use **Azure Active Directory v2** as the service provider, your AAD app''s client ID/secret/tenant ID, and `User.Read` as the scope. Save the connection name and add it to your environment file as `CONNECTION_NAME` (the value referenced by the sample).
+In the Azure Portal, open the Azure Bot resource created by the CLI -> **Settings** -> **Configuration** -> **OAuth Connection Settings** and add a new connection. Use **Azure Active Directory v2** as the service provider, your AAD app's client ID/secret/tenant ID, and `User.Read` as the scope. Save the connection name and add it to your environment file as `CONNECTION_NAME` (the value referenced by the sample).
 
 > The Teams Developer CLI does not currently configure OAuth connections on the Azure Bot resource; this step still needs to be done in the portal.
 
-### 7. Setup Code
+#### 7. Setup Code
 
 **Navigate to the sample directory:**
 
@@ -229,7 +372,7 @@ pip install -r requirements.txt
 
 The CLI populates `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` from step 3. Manually add the `CONNECTION_NAME` value from step 6 to the same environment file.
 
-### 8. Start the Bot
+#### 8. Start the Bot
 
 For Node.js:
 ```bash
@@ -274,7 +417,7 @@ Detailed logs can help diagnose authentication and connection issues.
 **For Node.js (TypeScript)**, logging is configured directly in the app via `ConsoleLogger`:
 ```typescript
 const app = new App({
-  logger: new ConsoleLogger(''@samples/TeamsSDK/bot-auth-quickstart'', { level: ''debug'' }),
+  logger: new ConsoleLogger('@samples/TeamsSDK/bot-auth-quickstart', { level: 'debug' }),
 });
 ```
 

--- a/samples/TeamsSDK/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/README.md
@@ -242,6 +242,8 @@ python main.py
 
 The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions the Microsoft Entra app, Azure Bot resource, and Teams app manifest, and writes the credentials into your project. The OAuth/SSO specifics (redirect URI, Application ID URI, manifest `webApplicationInfo` / `validDomains`, and the OAuth connection on the Azure Bot resource) are not yet automated by the CLI and are configured manually after provisioning.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive the CLI provisioning **and** the manual SSO/OAuth configuration steps below from natural language - the skill includes dedicated SSO setup guidance and can walk you through the portal steps the CLI does not yet automate.
+
 #### 1. Install the Teams Developer CLI
 
 ```bash
@@ -334,7 +336,7 @@ teams app update <teamsAppId> --file appPackage/<package>.zip
 
 In the Azure Portal, open the Azure Bot resource created by the CLI -> **Settings** -> **Configuration** -> **OAuth Connection Settings** and add a new connection. Use **Azure Active Directory v2** as the service provider, your AAD app's client ID/secret/tenant ID, and `User.Read` as the scope. Save the connection name and add it to your environment file as `CONNECTION_NAME` (the value referenced by the sample).
 
-> The Teams Developer CLI does not currently configure OAuth connections on the Azure Bot resource; this step still needs to be done in the portal.
+> The Teams Developer CLI does not currently configure OAuth connections on the Azure Bot resource; this step still needs to be done in the portal. If you installed the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills), your AI coding assistant can walk you through this portal configuration interactively.
 
 #### 7. Setup Code
 
@@ -454,6 +456,7 @@ app = App(logger=logger)
 ### Teams Development
 - [Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/) - Official Microsoft Teams platform documentation
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) - Command-line provisioning for Teams apps
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language (includes SSO setup guidance)
 
 ### Authentication & Graph API
 - [Teams Bot Authentication](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/authentication/auth-aad-sso-bots) - SSO authentication for Teams bots

--- a/samples/TeamsSDK/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/README.md
@@ -9,18 +9,18 @@ This sample demonstrates how to implement Single Sign-On (SSO) authentication fo
 
 > **IMPORTANT**: The manifest file in this app requires the following fields for the Teams SDK OAuth flow:
 > - **`validDomains`**: Must include `"token.botframework.com"` to allow the OAuth token flow.
-> - **`webApplicationInfo`**: Must be configured with your Azure AD app's `id` (App Id / Client ID) and `resource` (e.g., `api://botid-{AppId}`). This is required for SSO authentication to work in Teams.
+> - **`webApplicationInfo`**: Must be configured with your Azure AD app''s `id` (App Id / Client ID) and `resource` (e.g., `api://botid-{AppId}`). This is required for SSO authentication to work in Teams.
 > Both fields must be present in any bot that uses Teams SSO or OAuth authentication.
 
 ## Table of Contents
 
-- [Interaction with Bot](#interaction-with-bot)
+- [Interaction with Bot](#interaction-with-bot-application)
 - [Sample Implementations](#sample-implementations)
 - [Microsoft Graph Integration](#microsoft-graph-integration)
 - [Prerequisites](#prerequisites)
 - [Setup Instructions](#setup-instructions)
   - [Option 1: Using Microsoft 365 Agents Toolkit](#option-1-using-microsoft-365-agents-toolkit-for-vs-code)
-  - [Option 2: Manual Setup](#option-2-manual-setup)
+  - [Option 2: Teams Developer CLI + SSO configuration](#option-2-teams-developer-cli--sso-configuration)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
@@ -51,7 +51,7 @@ This sample demonstrates comprehensive Microsoft Graph API integration to access
 The bot leverages Microsoft Graph to:
 
 1. **User Profile Access**:
-   - Retrieves authenticated user's profile information
+   - Retrieves authenticated user''s profile information
    - Accesses user display name, email, job title, department, and office location
    - Uses delegated permissions on behalf of the signed-in user
 
@@ -60,7 +60,7 @@ The bot leverages Microsoft Graph to:
 This sample requires the following Microsoft Graph permissions:
 
 **Delegated Permissions** (user or admin consent required):
-- `User.Read` - Read the signed-in user's profile
+- `User.Read` - Read the signed-in user''s profile
 
 ### User Authentication Flow
 
@@ -68,7 +68,7 @@ The sample uses Azure AD SSO (Single Sign-On) with the Teams SDK OAuth flow:
 
 1. User initiates login via the bot
 2. Bot sends an Adaptive Card configured with the OAuth Signing Resource
-3. Teams prompts the user for consent (on first use) — see [Consent Flow](#consent-flow) below
+3. Teams prompts the user for consent (on first use) - see [Consent Flow](#consent-flow) below
 4. Bot exchanges the SSO token with permissions to access Graph resources
 5. Bot makes Graph API calls on behalf of the user
 
@@ -76,17 +76,17 @@ The sample uses Azure AD SSO (Single Sign-On) with the Teams SDK OAuth flow:
 
 Teams SSO involves two types of consent:
 
-- **User consent**: On the first sign-in, the user is prompted to consent to the permissions (e.g., `User.Read`). After consent is granted, subsequent sign-ins are silent — no prompt is shown.
-- **Admin consent**: An organization's administrator can pre-consent on behalf of all users in the tenant. If admin consent has been granted, individual users will not see a consent prompt.
+- **User consent**: On the first sign-in, the user is prompted to consent to the permissions (e.g., `User.Read`). After consent is granted, subsequent sign-ins are silent - no prompt is shown.
+- **Admin consent**: An organization''s administrator can pre-consent on behalf of all users in the tenant. If admin consent has been granted, individual users will not see a consent prompt.
 
 > **Note**: If you need to reset consent and re-trigger the consent prompt (e.g., for testing), you can do so by:
-> 1. Go to [My Apps](https://myapps.microsoft.com) → find your app → **Remove** it, or
-> 2. In the [Azure Portal](https://portal.azure.com) → **Microsoft Entra ID** → **Enterprise Applications** → find your app → **Permissions** → **Revoke user consent**, or
+> 1. Go to [My Apps](https://myapps.microsoft.com) -> find your app -> **Remove** it, or
+> 2. In the [Azure Portal](https://portal.azure.com) -> **Microsoft Entra ID** -> **Enterprise Applications** -> find your app -> **Permissions** -> **Revoke user consent**, or
 > 3. Have the user sign out of the bot (`signout` command) and clear the Teams app cache.
 
 ### Graph API Endpoints Used
 
-- `GET /me` - Get current user's profile
+- `GET /me` - Get current user''s profile
 
 ## Prerequisites
 
@@ -97,8 +97,9 @@ Teams SSO involves two types of consent:
   - **Node.js**: [NodeJS](https://nodejs.org/en/download/)
   - **.NET**: [.NET SDK](https://dotnet.microsoft.com/download)
   - **Python**: [Python](https://www.python.org/downloads/)
+- An Azure subscription (the SSO/OAuth flow requires an Azure Bot resource, not a Teams-managed bot)
 
-> **Note**: Authentication samples require Microsoft Teams and cannot be tested using the `agentsplayground` tool or the Teams SDK Dev Tools. The OAuth flow and SSO authentication features only work within the Teams client environment.
+> **Note**: Authentication samples (OAuth, SSO) only work inside the Microsoft Teams client and cannot be exercised in the Teams SDK Dev Tools.
 
 ## Setup Instructions
 
@@ -113,81 +114,122 @@ Teams SSO involves two types of consent:
 
 > **Note**: If you use multiple browser profiles, ATK may open the default browser where your account is not signed in. If the app is not found, copy the URL from the default browser and paste it into your preferred browser profile.
 
-### Option 2: Manual Setup
+### Option 2: Teams Developer CLI + SSO configuration
 
-#### 1. Setup for Bot SSO
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions the Microsoft Entra app, Azure Bot resource, and Teams app manifest, and writes the credentials into your project. The OAuth/SSO specifics (redirect URI, Application ID URI, manifest `webApplicationInfo` / `validDomains`, and the OAuth connection on the Azure Bot resource) are not yet automated by the CLI and are configured manually after provisioning.
 
-- Refer to [Bot SSO Setup document](BotSSOSetup.md)
-- Ensure that you've [enabled the Teams Channel](https://docs.microsoft.com/en-us/azure/bot-service/channel-connect-teams?view=azure-bot-service-4.0)
-- While registering the Azure bot, use `https://<your_tunnel_domain>/api/messages` as the messaging endpoint
+#### 1. Install the Teams Developer CLI
 
-> NOTE: When you create your app registration in Azure portal, you will create a ClientID and ClientSecret - make sure you keep these for later.
+```bash
+npm install -g @microsoft/teams.cli
+teams login
+```
 
 #### 2. Setup Local Tunnel
 
 Create a persistent tunnel for port 3978 with anonymous access so it can be reused across projects:
 
-```
+```bash
 devtunnel create -a my-tunnel
 devtunnel port create -p 3978 my-tunnel
 devtunnel host my-tunnel
 ```
 
-Take note of the URL shown after *Connect via browser:*
+Take note of the URL shown after *Connect via browser:*.
 
-#### 3. Register Azure AD Application
+#### 3. Provision the App with the Teams Developer CLI
 
-Register a new application in the [Microsoft Entra ID – App Registrations](https://go.microsoft.com/fwlink/?linkid=2083908) portal.
+From the language-specific sample directory you want to run, provision the Microsoft Entra app, Azure Bot resource, and manifest, and write credentials into your environment file. SSO requires an Azure-hosted bot, so the `--azure` flag is required:
 
-**A) Create New Registration:**
-- Select **New Registration** and on the *register an application page*, set following values:
-  - Set **name** to your app name
-  - Choose the **supported account types** (any account type will work)
-  - Leave **Redirect URI** empty
-  - Choose **Register**
+For Node.js and Python (`nodejs/bot-auth-quickstart` or `python/bot-auth-quickstart`):
 
-**B) Add Authentication Platform:**
-- Under **Manage**, navigate to **Authentication**
-- Click **Add a platform** and select **Web**
+```bash
+teams app create --name "Bot Auth Quickstart" --azure \
+  --subscription <azure-subscription-id> \
+  --resource-group <azure-resource-group> --create-resource-group \
+  --endpoint https://<your-tunnel-domain>/api/messages --env .env
+```
+
+For .NET (`dotnet/bot-auth-quickstart`):
+
+```bash
+teams app create --name "Bot Auth Quickstart" --azure \
+  --subscription <azure-subscription-id> \
+  --resource-group <azure-resource-group> --create-resource-group \
+  --endpoint https://<your-tunnel-domain>/api/messages --env appsettings.json
+```
+
+The command creates the Microsoft Entra app registration, an Azure Bot resource pointing at your tunnel endpoint, a Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified. Save the printed Teams app ID and Bot resource name for the next steps.
+
+#### 4. Configure the AAD App for SSO
+
+Open the app registration the CLI just created in the [Microsoft Entra ID - App Registrations](https://go.microsoft.com/fwlink/?linkid=2083908) portal.
+
+**A) Add the OAuth redirect URI:**
+
+- Under **Manage**, navigate to **Authentication** -> **Add a platform** -> **Web**
 - Set the **Redirect URI** to `https://token.botframework.com/.auth/web/redirect`
 - Click **Configure**
 
-**C) Save Application Details (skip if already done):**
-- On the overview page, copy and save the **Application (client) ID** and **Directory (tenant) ID**
-- You'll need these later when updating your Teams application manifest and configuration files
+**B) Expose an Application ID URI:**
 
-**D) Create Client Secret:**
-- Under **Manage**, navigate to **Certificates & secrets**
-- In the **Client secrets** section, click on **+ New client secret**
-- Add a description (e.g., "Teams Bot Secret") and select an expiration period
-- Click **Add**
-- **Important**: Copy the client secret **Value** immediately and save it securely. You won't be able to see it again!
+- Under **Manage**, navigate to **Expose an API**
+- Click **Add** next to **Application ID URI** and set it to `api://botid-<Application (client) ID>` (the value used in `webApplicationInfo.resource` in the manifest)
 
-**E) Configure API Permissions:**
+**C) Verify Graph permissions:**
+
 - Navigate to **API Permissions**
-- Click **Add a permission**
-- Select **Microsoft Graph** -> **Delegated permissions**:
-  - `User.Read` (enabled by default)
-- Click **Add permissions**
-- Click **Grant admin consent** to grant admin consent for the required permissions
+- Ensure **Microsoft Graph** -> **Delegated** -> `User.Read` is present (added by default)
+- Click **Grant admin consent** if your tenant requires it
 
-#### 4. Setup Code
+For more SSO background, see [Bot SSO Setup document](BotSSOSetup.md).
 
-**Clone the repository:**
+#### 5. Configure the SSO Manifest Fields
+
+Edit `appPackage/manifest.json` (or `appManifest/manifest.json`) and add the SSO-specific blocks:
+
+```json
+"validDomains": [
+  "token.botframework.com",
+  "<your-tunnel-domain>"
+],
+"webApplicationInfo": {
+  "id": "<Application (client) ID>",
+  "resource": "api://botid-<Application (client) ID>"
+}
+```
+
+Re-package and re-upload the manifest:
 
 ```bash
-git clone https://github.com/OfficeDev/Microsoft-Teams-Samples.git
+teams app package
+teams app update <teamsAppId> --file appPackage/<package>.zip
 ```
+
+#### 6. Create the OAuth Connection on the Azure Bot
+
+In the Azure Portal, open the Azure Bot resource created by the CLI -> **Settings** -> **Configuration** -> **OAuth Connection Settings** and add a new connection. Use **Azure Active Directory v2** as the service provider, your AAD app''s client ID/secret/tenant ID, and `User.Read` as the scope. Save the connection name and add it to your environment file as `CONNECTION_NAME` (the value referenced by the sample).
+
+> The Teams Developer CLI does not currently configure OAuth connections on the Azure Bot resource; this step still needs to be done in the portal.
+
+#### 7. Setup Code
 
 **Navigate to the sample directory:**
 
 ```bash
 # For Node.js:
 cd samples/TeamsSDK/bot-auth-quickstart/nodejs/bot-auth-quickstart
+
+# For .NET:
+cd samples/TeamsSDK/bot-auth-quickstart/dotnet/bot-auth-quickstart
+
+# For Python:
+cd samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart
 ```
 
 **Install dependencies:**
 
+For Node.js:
 ```bash
 npm install
 ```
@@ -202,33 +244,11 @@ For Python:
 pip install -r requirements.txt
 ```
 
-**Configure environment variables:**
+**Confirm environment variables:**
 
-Update the configuration file (`.env`, `appsettings.json`, or `.env` depending on language) with the values from step 3 (Azure AD app registration):
+The CLI populates `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` from step 3. Manually add the `CONNECTION_NAME` value from step 6 to the same environment file.
 
-- `CLIENT_ID` - The Application (client) ID from step 3
-- `CLIENT_SECRET` - The client secret value from step 3C
-- `TENANT_ID` - Your Directory (tenant) ID from step 3 (required for SingleTenant)
-- `CONNECTION_NAME` - The name of your Azure Bot OAuth connection created in step 1
-
-#### 5. Setup Teams App
-
-Navigate to the Teams Developer Portal at http://dev.teams.microsoft.com
-
-**Create a new Bot resource:**
-1. Navigate to **Tools** -> **Bot management**, and add a **New bot**
-2. In **Configure**, paste the devtunnel endpoint URL and append `/api/messages`
-3. In **Client secrets**, create a new secret and save it for later
-
-> **Note**: If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
-
-**Create a new Teams App:**
-1. Navigate to **Apps** and create a **New App**
-2. Fill the required values in **Basic information** (short and long name, descriptions, and App URLs)
-3. In **App features** -> **Bot**, select the bot you created previously
-4. Select **Preview in Teams**
-
-#### 6. Start the Bot
+#### 8. Start the Bot
 
 For Node.js:
 ```bash
@@ -248,11 +268,11 @@ python main.py
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable
-- Ensure your configuration file (`.env`, `appsettings.json`) is setup correctly
-- Verify that "token.botframework.com" is included in `validDomains` in your manifest.json
+- Ensure your configuration file (`.env`, `appsettings.json`) is set up correctly
+- Verify that `"token.botframework.com"` is included in `validDomains` in your manifest.json
 - For OAuth issues, confirm your Azure AD app registration has the correct redirect URIs
 - Check that admin consent has been granted for the required Graph API permissions
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors (not available in Teams Developer Portal)
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors
 
 ### Enabling Verbose Logs
 
@@ -273,7 +293,7 @@ Detailed logs can help diagnose authentication and connection issues.
 **For Node.js (TypeScript)**, logging is configured directly in the app via `ConsoleLogger`:
 ```typescript
 const app = new App({
-  logger: new ConsoleLogger('@samples/TeamsSDK/bot-auth-quickstart', { level: 'debug' }),
+  logger: new ConsoleLogger(''@samples/TeamsSDK/bot-auth-quickstart'', { level: ''debug'' }),
 });
 ```
 
@@ -294,7 +314,7 @@ app = App(logger=logger)
 
 **Invalid connection name**
 - The OAuth connection name in your bot code does not match the connection name configured in Azure Bot Service.
-- In the Azure Portal, go to your Azure Bot resource → **Settings** → **OAuth Connection Settings** and verify the connection name matches the value used in your code (e.g., `connectionName` in `.env` or `appsettings.json`).
+- In the Azure Portal, go to your Azure Bot resource -> **Settings** -> **OAuth Connection Settings** and verify the connection name matches the value used in your code (e.g., `connectionName` in `.env` or `appsettings.json`).
 
 **Invalid OAuth connection settings**
 - The OAuth connection in Azure Bot Service is misconfigured (wrong client ID, client secret, or tenant ID).
@@ -303,12 +323,13 @@ app = App(logger=logger)
 
 **Redirect URI not set**
 - The redirect URI required by the OAuth flow is missing from the Azure AD app registration.
-- In the Azure Portal, open your app registration → **Authentication** → **Redirect URIs** and add `https://token.botframework.com/.auth/web/redirect`.
+- In the Azure Portal, open your app registration -> **Authentication** -> **Redirect URIs** and add `https://token.botframework.com/.auth/web/redirect`.
 
 ## Further Reading
 
 ### Teams Development
 - [Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/) - Official Microsoft Teams platform documentation
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) - Command-line provisioning for Teams apps
 
 ### Authentication & Graph API
 - [Teams Bot Authentication](https://learn.microsoft.com/microsoftteams/platform/bots/how-to/authentication/auth-aad-sso-bots) - SSO authentication for Teams bots

--- a/samples/TeamsSDK/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/README.md
@@ -310,26 +310,14 @@ Open the app registration the CLI just created in the [Microsoft Entra ID - App 
 
 For more SSO background, see [Bot SSO Setup document](BotSSOSetup.md).
 
-#### 5. Configure the SSO Manifest Fields
+#### 5. Configure the SSO `webApplicationInfo` Fields
 
-Edit `appPackage/manifest.json` (or `appManifest/manifest.json`) and add the SSO-specific blocks:
-
-```json
-"validDomains": [
-  "token.botframework.com",
-  "<your-tunnel-domain>"
-],
-"webApplicationInfo": {
-  "id": "<Application (client) ID>",
-  "resource": "api://botid-<Application (client) ID>"
-}
-```
-
-Re-package and re-upload the manifest:
+Set the SSO `webApplicationInfo.id` and `webApplicationInfo.resource` directly on the Teams app via the CLI — no manual `manifest.json` edits or re-packaging required (`teams app create` already seeds `validDomains` with `*.botframework.com` and your tunnel domain):
 
 ```bash
-teams app package
-teams app update <teamsAppId> --file appPackage/<package>.zip
+teams app update <teamsAppId> \
+  --web-app-info-id "<Application (client) ID>" \
+  --web-app-info-resource "api://botid-<Application (client) ID>"
 ```
 
 #### 6. Create the OAuth Connection on the Azure Bot

--- a/samples/TeamsSDK/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/README.md
@@ -5,8 +5,6 @@ This sample demonstrates how to implement Single Sign-On (SSO) authentication fo
 - **Authentication**: Seamless SSO authentication using Azure AD with OAuth support
 - **Microsoft Graph Integration**: Access user data and perform operations on behalf of authenticated users
 
-> If you do not have permission to sideload custom apps, Microsoft 365 Agents Toolkit will recommend creating and using a Microsoft 365 Developer Program account - a free program to get your own dev environment sandbox that includes Teams.
-
 > **IMPORTANT**: The manifest file in this app requires the following fields for the Teams SDK OAuth flow:
 > - **`validDomains`**: Must include `"token.botframework.com"` to allow the OAuth token flow.
 > - **`webApplicationInfo`**: Must be configured with your Azure AD app''s `id` (App Id / Client ID) and `resource` (e.g., `api://botid-{AppId}`). This is required for SSO authentication to work in Teams.
@@ -19,8 +17,6 @@ This sample demonstrates how to implement Single Sign-On (SSO) authentication fo
 - [Microsoft Graph Integration](#microsoft-graph-integration)
 - [Prerequisites](#prerequisites)
 - [Setup Instructions](#setup-instructions)
-  - [Option 1: Using Microsoft 365 Agents Toolkit](#option-1-using-microsoft-365-agents-toolkit-for-vs-code)
-  - [Option 2: Teams Developer CLI + SSO configuration](#option-2-teams-developer-cli--sso-configuration)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
@@ -99,33 +95,18 @@ Teams SSO involves two types of consent:
   - **Python**: [Python](https://www.python.org/downloads/)
 - An Azure subscription (the SSO/OAuth flow requires an Azure Bot resource, not a Teams-managed bot)
 
-> **Note**: Authentication samples (OAuth, SSO) only work inside the Microsoft Teams client and cannot be exercised in the Teams SDK Dev Tools.
-
 ## Setup Instructions
-
-### Option 1: Using Microsoft 365 Agents Toolkit
-
-1. Ensure you have downloaded and installed [Visual Studio Code](https://code.visualstudio.com/docs/setup/setup-overview)
-2. Install the [Microsoft 365 Agents Toolkit extension](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension)
-3. Select **File > Open Folder** in VS Code and choose this sample directory (for Node.js/Python), or open the `.sln` solution file in Visual Studio (for .NET)
-4. Using the extension, sign in with your Microsoft 365 account where you have permissions to upload custom apps
-5. Select **Debug > Start Debugging** or **F5** to run the app in a Teams web client
-6. In the browser that launches, select the **Add** button to install the app to Teams
-
-> **Note**: If you use multiple browser profiles, ATK may open the default browser where your account is not signed in. If the app is not found, copy the URL from the default browser and paste it into your preferred browser profile.
-
-### Option 2: Teams Developer CLI + SSO configuration
 
 The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions the Microsoft Entra app, Azure Bot resource, and Teams app manifest, and writes the credentials into your project. The OAuth/SSO specifics (redirect URI, Application ID URI, manifest `webApplicationInfo` / `validDomains`, and the OAuth connection on the Azure Bot resource) are not yet automated by the CLI and are configured manually after provisioning.
 
-#### 1. Install the Teams Developer CLI
+### 1. Install the Teams Developer CLI
 
 ```bash
 npm install -g @microsoft/teams.cli
 teams login
 ```
 
-#### 2. Setup Local Tunnel
+### 2. Setup Local Tunnel
 
 Create a persistent tunnel for port 3978 with anonymous access so it can be reused across projects:
 
@@ -137,7 +118,7 @@ devtunnel host my-tunnel
 
 Take note of the URL shown after *Connect via browser:*.
 
-#### 3. Provision the App with the Teams Developer CLI
+### 3. Provision the App with the Teams Developer CLI
 
 From the language-specific sample directory you want to run, provision the Microsoft Entra app, Azure Bot resource, and manifest, and write credentials into your environment file. SSO requires an Azure-hosted bot, so the `--azure` flag is required:
 
@@ -161,7 +142,7 @@ teams app create --name "Bot Auth Quickstart" --azure \
 
 The command creates the Microsoft Entra app registration, an Azure Bot resource pointing at your tunnel endpoint, a Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified. Save the printed Teams app ID and Bot resource name for the next steps.
 
-#### 4. Configure the AAD App for SSO
+### 4. Configure the AAD App for SSO
 
 Open the app registration the CLI just created in the [Microsoft Entra ID - App Registrations](https://go.microsoft.com/fwlink/?linkid=2083908) portal.
 
@@ -184,7 +165,7 @@ Open the app registration the CLI just created in the [Microsoft Entra ID - App 
 
 For more SSO background, see [Bot SSO Setup document](BotSSOSetup.md).
 
-#### 5. Configure the SSO Manifest Fields
+### 5. Configure the SSO Manifest Fields
 
 Edit `appPackage/manifest.json` (or `appManifest/manifest.json`) and add the SSO-specific blocks:
 
@@ -206,13 +187,13 @@ teams app package
 teams app update <teamsAppId> --file appPackage/<package>.zip
 ```
 
-#### 6. Create the OAuth Connection on the Azure Bot
+### 6. Create the OAuth Connection on the Azure Bot
 
 In the Azure Portal, open the Azure Bot resource created by the CLI -> **Settings** -> **Configuration** -> **OAuth Connection Settings** and add a new connection. Use **Azure Active Directory v2** as the service provider, your AAD app''s client ID/secret/tenant ID, and `User.Read` as the scope. Save the connection name and add it to your environment file as `CONNECTION_NAME` (the value referenced by the sample).
 
 > The Teams Developer CLI does not currently configure OAuth connections on the Azure Bot resource; this step still needs to be done in the portal.
 
-#### 7. Setup Code
+### 7. Setup Code
 
 **Navigate to the sample directory:**
 
@@ -248,7 +229,7 @@ pip install -r requirements.txt
 
 The CLI populates `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` from step 3. Manually add the `CONNECTION_NAME` value from step 6 to the same environment file.
 
-#### 8. Start the Bot
+### 8. Start the Bot
 
 For Node.js:
 ```bash
@@ -337,5 +318,4 @@ app = App(logger=logger)
 - [Graph API Permissions](https://learn.microsoft.com/graph/permissions-reference) - Complete permissions reference
 
 ### Tools & Resources
-- [Microsoft 365 Agents Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension) - VS Code extension for Teams development
 - [Azure Bot Service](https://azure.microsoft.com/services/bot-services/) - Cloud-based bot development service

--- a/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/README.md
@@ -10,7 +10,7 @@ A Microsoft Teams bot with SSO authentication and Microsoft Graph integration.
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 - [Visual Studio Code](https://code.visualstudio.com/) with [Microsoft 365 Agents Toolkit](https://aka.ms/teams-toolkit) extension
 

--- a/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/README.md
+++ b/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/README.md
@@ -10,7 +10,7 @@ A Microsoft Teams bot with SSO authentication and Microsoft Graph integration.
 
 ## Prerequisites
 
-- [Python >=3.12, <3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 - [Visual Studio Code](https://code.visualstudio.com/) with [Microsoft 365 Agents Toolkit](https://aka.ms/teams-toolkit) extension
 

--- a/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/pyproject.toml
+++ b/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-auth-quickstart"
 version = "1.0.0"
 description = "Bot Auth Quickstart - Teams SDK"
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "python-dotenv>=1.0.0",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/pyproject.toml
+++ b/samples/TeamsSDK/bot-auth-quickstart/python/bot-auth-quickstart/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-auth-quickstart"
 version = "1.0.0"
 description = "Bot Auth Quickstart - Teams SDK"
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "python-dotenv>=1.0.0",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-cards/README.md
+++ b/samples/TeamsSDK/bot-cards/README.md
@@ -82,6 +82,8 @@ This single command creates a Microsoft Entra app registration, registers a Team
 
 Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive these CLI steps from natural language - your assistant runs the right commands, manages credentials, and guides you through bot registration end-to-end.
+
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
@@ -92,3 +94,4 @@ Once provisioning completes, start your bot - the sample will pick up the creden
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language

--- a/samples/TeamsSDK/bot-cards/README.md
+++ b/samples/TeamsSDK/bot-cards/README.md
@@ -8,8 +8,8 @@ This sample demonstrates how to handle various card types and interactive card b
 - [Sample Implementations](#sample-implementations)
 - [How to run these samples](#how-to-run-these-samples)
   - [Run in the Teams Client](#run-in-the-teams-client)
-- [Configure the new project to use the new Teams Bot Application](#configure-the-new-project-to-use-the-new-teams-bot-application)
-- [Pro Tip: Read the configuration settings using the Azure CLI](#pro-tip-read-the-configuration-settings-using-the-azure-cli)
+    - [Configure DevTunnels](#configure-devtunnels)
+  - [Provision with the Teams Developer CLI](#provision-with-the-teams-developer-cli)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
@@ -32,109 +32,63 @@ The bot responds to the following commands:
 
 # How to run these samples
 
-You can run these samples locally using:
-
-1. In the Teams Client after you have provisioned the Teams Application and configured the application with your local DevTunnels URL.
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project's environment file, and started the bot against a public DevTunnels URL.
 
 ## Run in the Teams Client
 
-To run these samples in the Teams Client, you need to provision your app in a M365 Tenant, and configure the app to your DevTunnels URL.
+To run these samples in the Teams Client, you need to provision your app in an M365 tenant and configure the app to your DevTunnels URL.
 
-1. Install the tool DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-2. Get Access to a M365 Developer Tenant https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started
-3. Create a Teams App with the Bot Feature in the Teams Developer Portal (in your tenant) https://dev.teams.microsoft.com
+1. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
+2. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
+3. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
 
 ### Configure DevTunnels
 
-Create a persistent tunnel for the port 3978 with anonymous access
+Create a persistent tunnel for port 3978 with anonymous access:
 
-```
-devtunnel create -a my-tunnel  
-devtunnel port create -p 3978  my-tunnel 
-devtunnel host  my-tunnel
+```bash
+devtunnel create -a my-tunnel
+devtunnel port create -p 3978 my-tunnel
+devtunnel host my-tunnel
 ```
 
 Take note of the URL shown after *Connect via browser:*
 
-### Provisioning the Teams Application
+## Provision with the Teams Developer CLI
 
-Navigate to the Teams Developer Portal http://dev.teams.microsoft.com
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project's environment file in a single command.
 
-#### Create a new Bot resource
+Sign in with your M365 account:
 
-1. Navigate to `Tools->Bot management`, and add a `New bot`
-1. In Configure, paste the Endpoint address from devtunnels and append `/api/messages`
-1. In Client secrets, create a new secret and save it for later
-
-> Note. If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
-
-#### Create a new Teams App
-
-1. Navigate to `Apps` and create a `New App`
-1. Fill the required values in Basic information (short and long name, short and long description and App URLs)
-1. In `App features->Bot` select the bot you created previously
-1. Select `Preview in Teams`
-
-> Note. When using an Azure Bot resource, provide the ClientID instead of selecting an existing bot.
-
-## Configure the new project to use the new Teams Bot Application
-
-For NodeJS and Python you will need a `.env` file with the next fields
-
-```
-TENANT_ID=
-CLIENT_ID=
-CLIENT_SECRET=
+```bash
+teams login
 ```
 
-For dotnet you need to add these values to `appsettings.json` or `launchSettings.json` using the next syntax.
+From the language-specific sample directory you want to run, provision the app and credentials.
 
-appsettings.json
+For Node.js and Python (`nodejs/<sample>` or `python/<sample>`):
 
-
-```json
-"urls" : "http://localhost:3978",
-"Teams": {
-    "ClientId": "",
-    "ClientSecret": "",
-    "TenantId": ""
-  },
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env .env
 ```
 
-Or to use Env Vars from the profile defined in `launchSettings.json` (using the Environment Configuration Provider)
+For .NET (`dotnet/<sample>`):
 
-```json
- "teamsbot": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:3978",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Teams__TenantId": "YOUR_TenantId",
-        "Teams__ClientId": "YOUR_ClientId",
-        "Teams__ClientSecret": "YOUR_ClientSecret"
-      }
-    }
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env appsettings.json
 ```
 
-## Pro Tip: Read the configuration settings using the Azure CLI
+This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your DevTunnels endpoint, generates and uploads the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
 
-To obtain the TenantId, ClientId and ClientSecret you can use the Azure CLI with:
-
-> Note. If you don't have access to an Azure Subscription you can still use the Azure CLI, make sure you login with `az login --allow-no-subscription`
-
-```
-az ad app credential reset --id $appId
-```
+Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
-- Ensure your .env or appsettings file is setup correctly.
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors (not available in Teams Developer Portal).
-
+- Ensure your `.env` or `appsettings.json` file is set up correctly.
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors.
 
 ## Further Reading
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)

--- a/samples/TeamsSDK/bot-cards/nodejs/bot-cards/README.md
+++ b/samples/TeamsSDK/bot-cards/nodejs/bot-cards/README.md
@@ -25,4 +25,4 @@ This sample demonstrates how to interact with adaptive cards in Microsoft Teams 
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-cards/python/bot-cards/README.md
+++ b/samples/TeamsSDK/bot-cards/python/bot-cards/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to interact with adaptive cards in Microsoft Teams 
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installation/)
 - [uv](https://docs.astral.sh/uv/)
 

--- a/samples/TeamsSDK/bot-cards/python/bot-cards/README.md
+++ b/samples/TeamsSDK/bot-cards/python/bot-cards/README.md
@@ -4,7 +4,7 @@ This sample demonstrates how to interact with adaptive cards in Microsoft Teams 
 
 ## Prerequisites
 
-- [Python >=3.12,<3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - [pip](https://pip.pypa.io/en/stable/installation/)
 - [uv](https://docs.astral.sh/uv/)
 
@@ -35,4 +35,4 @@ python main.py
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-cards/python/bot-cards/pyproject.toml
+++ b/samples/TeamsSDK/bot-cards/python/bot-cards/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-cards"
 version = "0.1.0"
 description = "Bot Cards sample"
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "python-dotenv>=1.2.2",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-cards/python/bot-cards/pyproject.toml
+++ b/samples/TeamsSDK/bot-cards/python/bot-cards/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-cards"
 version = "0.1.0"
 description = "Bot Cards sample"
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "python-dotenv>=1.2.2",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/README.md
@@ -92,6 +92,8 @@ This single command creates a Microsoft Entra app registration, registers a Team
 
 The CLI prints a Teams app ID on success - save it; you'll use it in step 5 when adding RSC permissions.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive the CLI provisioning, manifest, and RSC permission steps from natural language - your assistant runs the right commands, manages credentials, and can also help guide you through the portal-only steps below (Graph permissions, application access policy, and meeting event subscriptions).
+
 ### 3. Add Graph API Permissions and Grant Admin Consent
 
 The CLI provisions a baseline Microsoft Entra app, but the meeting Graph API permissions used by this sample must still be added manually in the portal:
@@ -237,6 +239,7 @@ Once the bot is running and added to Teams, you can interact with it in meetings
 ### Teams Development
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/) - Official Microsoft Teams platform documentation
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) - Command-line provisioning for Teams apps
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language
 
 ### Meeting Events & Transcripts
 - [Meeting participant events](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet#receive-meeting-participant-events) - Real-time meeting participant events

--- a/samples/TeamsSDK/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/README.md
@@ -60,11 +60,11 @@ devtunnel host -p 3978 --allow-anonymous
 ngrok http 3978 --host-header="localhost:3978"
 ```
 
-Take note of the tunnel URL (e.g. `https://12345.devtunnels.ms` or `https://1234.ngrok-free.app`); you''ll use it as the bot messaging endpoint and tunnel domain in subsequent steps.
+Take note of the tunnel URL (e.g. `https://12345.devtunnels.ms` or `https://1234.ngrok-free.app`); you'll use it as the bot messaging endpoint and tunnel domain in subsequent steps.
 
 ### 2. Provision the App with the Teams Developer CLI
 
-The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project''s environment file in a single command.
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project's environment file in a single command.
 
 Sign in with your M365 account:
 
@@ -90,7 +90,7 @@ teams app create --name "Bot Meetings" --teams-managed --endpoint https://<your-
 
 This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your tunnel endpoint, generates the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
 
-The CLI prints a Teams app ID on success - save it; you''ll use it in step 5 when adding RSC permissions.
+The CLI prints a Teams app ID on success - save it; you'll use it in step 5 when adding RSC permissions.
 
 ### 3. Add Graph API Permissions and Grant Admin Consent
 

--- a/samples/TeamsSDK/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/README.md
@@ -72,18 +72,20 @@ Sign in with your M365 account:
 teams login
 ```
 
-From the language-specific sample directory you want to run, provision the app and credentials.
+This sample uses a Teams-managed bot (registered with the Teams Developer Portal). The bot **cannot** be hosted as an Azure Bot resource - meeting event subscriptions are only available on Teams-managed bots.
+
+From the language-specific sample directory you want to run, provision the app and credentials. The `--teams-managed` flag is the default but is shown here for clarity.
 
 For Node.js and Python (`nodejs/bot-meetings` or `python/bot-meetings`):
 
 ```bash
-teams app create --name "Bot Meetings" --endpoint https://<your-tunnel-domain>/api/messages --env .env
+teams app create --name "Bot Meetings" --teams-managed --endpoint https://<your-tunnel-domain>/api/messages --env .env
 ```
 
 For .NET (`dotnet/bot-meetings`):
 
 ```bash
-teams app create --name "Bot Meetings" --endpoint https://<your-tunnel-domain>/api/messages --env appsettings.json
+teams app create --name "Bot Meetings" --teams-managed --endpoint https://<your-tunnel-domain>/api/messages --env appsettings.json
 ```
 
 This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your tunnel endpoint, generates the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
@@ -136,7 +138,7 @@ These permissions allow the bot to:
 
 **Enable meeting participant events:**
 
-To receive real-time participant join and leave events, enable Meeting event subscriptions for `Participant Join` and `Participant Leave` on the bot registration. The Teams CLI does not currently expose meeting-event subscriptions, so configure them on the bot resource directly (e.g. in the Azure portal for an Azure Bot resource) following the guidance in the [meeting participant events](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet#receive-meeting-participant-events) documentation.
+To receive real-time participant join and leave events, you must enable Meeting event subscriptions for `Participant Join` and `Participant Leave` on the bot registration. The Teams Developer CLI does not currently expose meeting-event subscriptions, so this toggle is configured in the [Teams Developer Portal](https://dev.teams.microsoft.com): open the bot the CLI created under **Tools** -> **Bot management**, then enable the participant join/leave events. See the [meeting participant events](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet#receive-meeting-participant-events) documentation for details.
 
 ![Extra Setup](Images/event_subscription.png)
 
@@ -228,8 +230,7 @@ Once the bot is running and added to Teams, you can interact with it in meetings
 - Ensure your `.env` or `appsettings.json` file is set up correctly
 - Verify that admin consent has been granted for the required Graph API permissions
 - Check that the application access policy has been configured correctly for your user
-- Confirm that Meeting event subscriptions are enabled in the bot registration
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors
+- Confirm that Meeting event subscriptions are enabled in the bot registration (in the [Teams Developer Portal](https://dev.teams.microsoft.com), under **Tools** -> **Bot management** -> your bot)
 
 ## Further Reading
 
@@ -242,4 +243,4 @@ Once the bot is running and added to Teams, you can interact with it in meetings
 - [Configure application access policy](https://docs.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy) - Application access for online meetings
 
 ### Tools & Resources
-- [Azure Bot Service](https://azure.microsoft.com/services/bot-services/) - Cloud-based bot development service
+- [Teams Developer Portal](https://dev.teams.microsoft.com) - Manage Teams-managed bot registrations and meeting event subscriptions

--- a/samples/TeamsSDK/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/README.md
@@ -13,6 +13,12 @@ This sample demonstrates how to handle real-time meeting events and retrieve mee
 - [Sample Implementations](#sample-implementations)
 - [Prerequisites](#prerequisites)
 - [Setup Instructions](#setup-instructions)
+  - [1. Setup Local Tunnel](#1-setup-local-tunnel)
+  - [2. Provision the App with the Teams Developer CLI](#2-provision-the-app-with-the-teams-developer-cli)
+  - [3. Add Graph API Permissions and Grant Admin Consent](#3-add-graph-api-permissions-and-grant-admin-consent)
+  - [4. Configure Application Access Policy](#4-configure-application-access-policy)
+  - [5. Add RSC Permissions and Enable Meeting Participant Events](#5-add-rsc-permissions-and-enable-meeting-participant-events)
+  - [6. Setup Code](#6-setup-code)
 - [Running the Sample](#running-the-sample)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
@@ -34,14 +40,9 @@ This sample demonstrates how to handle real-time meeting events and retrieve mee
 - Microsoft Teams is installed and you have an account (not a guest account)
 - [M365 developer account](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/build-and-test/prepare-your-o365-tenant) or access to a Teams account with the appropriate permissions to install an app
 - [dev tunnel](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started?tabs=windows) or [ngrok](https://ngrok.com/download) latest version or equivalent tunneling solution
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
 
 ## Setup Instructions
-
-To run these samples in the Teams Client, you need to provision your app in a M365 Tenant, and configure the app to your DevTunnels URL.
-
-1. Install the tool DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-2. Get Access to a M365 Developer Tenant https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started
-3. Create a Teams App with the Bot Feature in the Teams Developer Portal (in your tenant) https://dev.teams.microsoft.com
 
 ### 1. Setup Local Tunnel
 
@@ -59,70 +60,112 @@ devtunnel host -p 3978 --allow-anonymous
 ngrok http 3978 --host-header="localhost:3978"
 ```
 
+Take note of the tunnel URL (e.g. `https://12345.devtunnels.ms` or `https://1234.ngrok-free.app`); you''ll use it as the bot messaging endpoint and tunnel domain in subsequent steps.
 
-### 2. Register Azure AD Application
+### 2. Provision the App with the Teams Developer CLI
 
-Register a new application in the [Microsoft Entra ID – App Registrations](https://go.microsoft.com/fwlink/?linkid=2083908) portal.
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project''s environment file in a single command.
 
-**A) Create New Registration:**
-- Select **New Registration** and on the *register an application page*, set following values:
-  - Set **name** to your app name
-  - Choose the **supported account types** (any account type will work)
-  - Leave **Redirect URI** empty
-  - Choose **Register**
+Sign in with your M365 account:
 
-**B) Save Application Details:**
-- On the overview page, copy and save the **Application (client) ID** and **Directory (tenant) ID**
-- You'll need these later when updating your Teams application manifest and configuration files
+```bash
+teams login
+```
 
-**C) Create Client Secret:**
-- Under **Manage**, navigate to **Certificates & secrets**
-- In the **Client secrets** section, click on **+ New client secret**
-- Add a description (e.g., "Teams Bot Secret") and select an expiration period
-- Click **Add**
-- **Important**: Copy the client secret **Value** immediately and save it securely. You won't be able to see it again!
+From the language-specific sample directory you want to run, provision the app and credentials.
 
-**D) Configure API Permissions:**
-- Navigate to **API Permissions**
-- Click **Add a permission**
-- Select **Microsoft Graph** -> **Delegated permissions**:
-  - `User.Read` (enabled by default)
-- Select **Microsoft Graph** -> **Application permissions**:
+For Node.js and Python (`nodejs/bot-meetings` or `python/bot-meetings`):
+
+```bash
+teams app create --name "Bot Meetings" --endpoint https://<your-tunnel-domain>/api/messages --env .env
+```
+
+For .NET (`dotnet/bot-meetings`):
+
+```bash
+teams app create --name "Bot Meetings" --endpoint https://<your-tunnel-domain>/api/messages --env appsettings.json
+```
+
+This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your tunnel endpoint, generates the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
+
+The CLI prints a Teams app ID on success - save it; you''ll use it in step 5 when adding RSC permissions.
+
+### 3. Add Graph API Permissions and Grant Admin Consent
+
+The CLI provisions a baseline Microsoft Entra app, but the meeting Graph API permissions used by this sample must still be added manually in the portal:
+
+- Open your app registration in the [Microsoft Entra ID - App Registrations](https://go.microsoft.com/fwlink/?linkid=2083908) portal (it will be named "Bot Meetings" from step 2)
+- Navigate to **API Permissions** -> **Add a permission** -> **Microsoft Graph**
+- Under **Delegated permissions**, ensure `User.Read` is present (added by default)
+- Under **Application permissions**, add:
   - `OnlineMeetings.Read.All` (for reading meeting information)
   - `OnlineMeetingTranscript.Read.All` (for reading meeting transcripts)
 - Click **Add permissions**
-- Click **Grant admin consent** to grant admin consent for the required permissions
+- Click **Grant admin consent** to consent for the required permissions
 
 > **Note**: Admin consent is required for application permissions. If you are not a Global Administrator, contact your tenant admin to grant consent, or use this link: `https://login.microsoftonline.com/common/adminconsent?client_id=<YOUR_APP_ID>`
 
-**E) Configure Application Access Policy:**
+### 4. Configure Application Access Policy
+
+Online meeting application access policies cannot be configured through the Teams CLI; they must be created and granted via PowerShell.
 
 Follow this link - [Configure application access policy](https://docs.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy)
 
 Follow this link - [Manage policies via PowerShell](https://learn.microsoft.com/en-us/microsoftteams/teams-powershell-managing-teams#manage-policies-via-powershell)
 
-
 ![Policy](Images/Policy.png)
 
-### 3. Create Bot Registration
+### 5. Add RSC Permissions and Enable Meeting Participant Events
 
-Navigate to the Teams Developer Portal http://dev.teams.microsoft.com
+**Add RSC permissions via the Teams CLI:**
 
-**Create a new Bot resource:**
+Using the Teams app ID returned by `teams app create` in step 2, add the resource-specific consent permissions this sample requires:
 
-1. Navigate to `Tools->Bot management`, and add a `New bot`
-2. In Configure, paste the Endpoint address from devtunnels and append `/api/messages`
-3. In Client secrets, create a new secret and save it for later
+```bash
+teams app rsc add <teamsAppId> OnlineMeeting.ReadBasic.Chat --type Application
+teams app rsc add <teamsAppId> OnlineMeetingTranscript.Read.Chat --type Application
+teams app rsc add <teamsAppId> ChannelMeeting.ReadBasic.Group --type Application
+teams app rsc add <teamsAppId> OnlineMeetingParticipant.Read.Chat --type Application
+```
 
-> Note. If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
+These permissions allow the bot to:
+- Read basic meeting information
+- Access meeting transcripts
+- Read channel meeting details
+- Monitor meeting participant events
 
-**Enable Meeting Participant Events:**
+**Enable meeting participant events:**
 
-To receive real-time participant join and leave events, enable Meeting event subscriptions for `Participant Join` and `Participant Leave` in your bot on Teams Developer Portal by following the guidance in the [meeting participant events](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet#receive-meeting-participant-events) documentation.
+To receive real-time participant join and leave events, enable Meeting event subscriptions for `Participant Join` and `Participant Leave` on the bot registration. The Teams CLI does not currently expose meeting-event subscriptions, so configure them on the bot resource directly (e.g. in the Azure portal for an Azure Bot resource) following the guidance in the [meeting participant events](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet#receive-meeting-participant-events) documentation.
 
 ![Extra Setup](Images/event_subscription.png)
 
-### 4. Setup Code
+**Update manifest scopes:**
+
+Ensure the `bots` entry in `manifest.json` includes the `team`, `personal`, and `groupChat` scopes so the bot can be added to meetings:
+
+```json
+"bots": [
+  {
+    "botId": "",
+    "scopes": [
+      "team",
+      "personal",
+      "groupChat"
+    ],
+    "isNotificationOnly": false
+  }
+]
+```
+
+Re-package and re-upload the manifest if you make changes:
+
+```bash
+teams app package
+teams app update <teamsAppId> --file appPackage/<package>.zip
+```
+
+### 6. Setup Code
 
 **Navigate to your chosen language sample directory:**
 
@@ -154,52 +197,6 @@ For Python:
 pip install -e .
 ```
 
-**Configure environment variables:**
-
-Update the configuration file for your selected language (for Node.js/Python, the `.env` file; for .NET, `appsettings.json` or `launchSettings.json`) with the values from step 2 (Azure AD app registration):
-
-For NodeJS and Python you will need a `.env` file with the following fields:
-
-```
-TENANT_ID=<Your Directory (tenant) ID>
-CLIENT_ID=<Your Application (client) ID>
-CLIENT_SECRET=<Your client secret value>
-```
-
-For .NET you need to add these values to `appsettings.json` or `launchSettings.json` using the next syntax:
-
-appSettings.json:
-
-```json
-"urls" : "http://localhost:3978",
-"Teams": {
-    "ClientID": "<Your Application (client) ID>",
-    "ClientSecret": "<Your client secret value>",
-    "TenantId": "<Your Directory (tenant) ID>"
-  },
-```
-
-Or to use Env Vars from the profile defined in `launchSettings.json` (using the Environment Configuration Provider):
-
-```json
- "teamsbot": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:3978",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Teams__TenantId": "YOUR_TenantId",
-        "Teams__ClientID": "YOUR_ClientId",
-        "Teams__ClientSecret": "YOUR_ClientSecret"
-      }
-    }
-```
-
-> **Pro Tip**: To obtain the TenantId, ClientId and SecretId you can use the Azure CLI with: `az ad app credential reset --id $appId`
-> 
-> Note. If you don't have access to an Azure Subscription you can still use the Azure CLI, make sure you login with `az login --allow-no-subscription`
-
 **Start the bot:**
 
 For Node.js:
@@ -217,72 +214,6 @@ For Python:
 python app.py
 ```
 
-### 5. Setup Teams App Manifest
-
-**Edit the manifest:**
-
-- Navigate to the `appManifest/` or `appPackage/` folder
-- Edit `manifest.json` and replace:
-  - `{MicrosoftAppId}` or `<<MICROSOFT-APP-ID>>` - Replace with your Application (client) ID from step 2 (appears in multiple places)
-  - `<<DOMAIN-NAME>>` - Replace with your tunnel domain:
-    - For ngrok: `1234.ngrok-free.app` (from `https://1234.ngrok-free.app`)
-    - For dev tunnels: `12345.devtunnels.ms`
-
-The scopes section must include team, and groupChat:
-
-```json
-"bots": [
-  {
-    "botId": "",
-    "scopes": [
-      "team",
-      "personal",
-      "groupChat"
-    ],
-    "isNotificationOnly": false
-  }
-]
-```
-
-**Configure RSC Permissions:**
-
-Add the following RSC (Resource-Specific Consent) permissions to your Teams app `manifest.json` file in the `webApplicationInfo.authorization.permissions.resourceSpecificPermissions` array:
-
-```json
-{
-    "name": "OnlineMeeting.ReadBasic.Chat",
-    "type": "Application"
-},
-{
-    "name": "OnlineMeetingTranscript.Read.Chat",
-    "type": "Application"
-},
-{
-    "name": "ChannelMeeting.ReadBasic.Group",
-    "type": "Application"
-},
-{
-    "name": "OnlineMeetingParticipant.Read.Chat",
-    "type": "Application"
-}
-```
-
-These permissions allow the bot to:
-- Read basic meeting information
-- Access meeting transcripts
-- Read channel meeting details
-- Monitor meeting participant events
-
-**Create app package:**
-
-- Zip up the contents of the `appManifest/` or `appPackage/` folder to create a `manifest.zip`
-
-**Upload to Teams:**
-
-- In Microsoft Teams, go to **Apps** (left sidebar)
-- Click **Manage your apps** → **Upload an app** → **Upload a custom app**
-- Select the `manifest.zip` file
-
 ## Running the Sample
 
 Once the bot is running and added to Teams, you can interact with it in meetings to:
@@ -293,23 +224,22 @@ Once the bot is running and added to Teams, you can interact with it in meetings
 
 ## Troubleshooting
 
-- If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable
-- Ensure your .env or appsettings file is setup correctly
+- If Teams cannot communicate with your bot, verify your tunnel URL is reachable
+- Ensure your `.env` or `appsettings.json` file is set up correctly
 - Verify that admin consent has been granted for the required Graph API permissions
 - Check that the application access policy has been configured correctly for your user
 - Confirm that Meeting event subscriptions are enabled in the bot registration
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors (not available in Teams Developer Portal)
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors
 
 ## Further Reading
 
 ### Teams Development
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/) - Official Microsoft Teams platform documentation
-- [Microsoft Teams Developer Platform](https://docs.microsoft.com/en-us/microsoftteams/platform/) - Comprehensive guide for Teams app development
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) - Command-line provisioning for Teams apps
 
 ### Meeting Events & Transcripts
 - [Meeting participant events](https://learn.microsoft.com/microsoftteams/platform/apps-in-teams-meetings/meeting-apps-apis?tabs=dotnet#receive-meeting-participant-events) - Real-time meeting participant events
 - [Configure application access policy](https://docs.microsoft.com/en-us/graph/cloud-communication-online-meeting-application-access-policy) - Application access for online meetings
 
 ### Tools & Resources
-- [Microsoft 365 Agents Toolkit](https://marketplace.visualstudio.com/items?itemName=TeamsDevApp.ms-teams-vscode-extension) - VS Code extension for Teams development
 - [Azure Bot Service](https://azure.microsoft.com/services/bot-services/) - Cloud-based bot development service

--- a/samples/TeamsSDK/bot-meetings/dotnet/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/dotnet/bot-meetings/README.md
@@ -20,4 +20,4 @@ This sample demonstrates a bot for Microsoft Teams that handles real-time meetin
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-meetings/nodejs/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/nodejs/bot-meetings/README.md
@@ -25,4 +25,4 @@ This sample demonstrates a bot for Microsoft Teams that handles real-time meetin
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-meetings/python/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/python/bot-meetings/README.md
@@ -4,7 +4,7 @@ This sample demonstrates a bot for Microsoft Teams that handles real-time meetin
 
 ## Prerequisites
 
-- [Python >=3.12, <3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample
@@ -34,4 +34,4 @@ python main.py
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-meetings/python/bot-meetings/README.md
+++ b/samples/TeamsSDK/bot-meetings/python/bot-meetings/README.md
@@ -4,7 +4,7 @@ This sample demonstrates a bot for Microsoft Teams that handles real-time meetin
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample

--- a/samples/TeamsSDK/bot-meetings/python/bot-meetings/pyproject.toml
+++ b/samples/TeamsSDK/bot-meetings/python/bot-meetings/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-meetings"
 version = "0.1.0"
 description = "This sample demonstrates a bot that handles meeting events and transcripts in Microsoft Teams using Python."
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "python-dotenv>=1.2.2",
     "microsoft-teams-apps[graph]==2.0.0",

--- a/samples/TeamsSDK/bot-meetings/python/bot-meetings/pyproject.toml
+++ b/samples/TeamsSDK/bot-meetings/python/bot-meetings/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-meetings"
 version = "0.1.0"
 description = "This sample demonstrates a bot that handles meeting events and transcripts in Microsoft Teams using Python."
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "python-dotenv>=1.2.2",
     "microsoft-teams-apps[graph]==2.0.0",

--- a/samples/TeamsSDK/bot-message-extensions/README.md
+++ b/samples/TeamsSDK/bot-message-extensions/README.md
@@ -8,9 +8,9 @@ This sample demonstrates a search-based messaging extension in Microsoft Teams t
 - [Sample Implementations](#sample-implementations)
 - [How to run these samples](#how-to-run-these-samples)
   - [Run in the Teams Client](#run-in-the-teams-client)
+    - [Configure DevTunnels](#configure-devtunnels)
+  - [Provision with the Teams Developer CLI](#provision-with-the-teams-developer-cli)
   - [Configure the App Manifest](#configure-the-app-manifest)
-- [Configure the new project to use the new Teams Bot Application](#configure-the-new-project-to-use-the-new-teams-bot-application)
-- [Pro Tip: Read the configuration settings using the Azure CLI](#pro-tip-read-the-configuration-settings-using-the-azure-cli)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
@@ -33,54 +33,57 @@ The extension supports the following capabilities:
 
 # How to run these samples
 
-You can run these samples locally using:
-
-1. In the Teams Client after you have provisioned the Teams Application and configured the application with your local DevTunnels URL.
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project''s environment file, and started the bot against a public DevTunnels URL.
 
 ## Run in the Teams Client
 
-To run these samples in the Teams Client, you need to provision your app in a M365 Tenant, and configure the app to your DevTunnels URL.
+To run these samples in the Teams Client, you need to provision your app in an M365 tenant and configure the app to your DevTunnels URL.
 
-1. Install the tool DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-2. Get Access to a M365 Developer Tenant https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started
-3. Create a Teams App with the Bot Feature in the Teams Developer Portal (in your tenant) https://dev.teams.microsoft.com
+1. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
+2. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
+3. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
 
 ### Configure DevTunnels
 
-Create a persistent tunnel for the port 3978 with anonymous access
+Create a persistent tunnel for port 3978 with anonymous access:
 
-```
-devtunnel create -a my-tunnel  
-devtunnel port create -p 3978  my-tunnel 
-devtunnel host  my-tunnel
+```bash
+devtunnel create -a my-tunnel
+devtunnel port create -p 3978 my-tunnel
+devtunnel host my-tunnel
 ```
 
 Take note of the URL shown after *Connect via browser:*
 
-### Provisioning the Teams Application
+## Provision with the Teams Developer CLI
 
-Navigate to the Teams Developer Portal http://dev.teams.microsoft.com
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project''s environment file in a single command.
 
-#### Create a new Bot resource
+Sign in with your M365 account:
 
-1. Navigate to `Tools->Bot management`, and add a `New bot`
-1. In Configure, paste the Endpoint address from devtunnels and append `/api/messages`
-1. In Client secrets, create a new secret and save it for later
+```bash
+teams login
+```
 
-> Note. If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
+From the language-specific sample directory you want to run, provision the app and credentials.
 
-#### Create a new Teams App
+For Node.js and Python (`nodejs/bot-message-extensions` or `python/bot-message-extensions`):
 
-1. Navigate to `Apps` and create a `New App`
-1. Fill the required values in Basic information (short and long name, short and long description and App URLs)
-1. In `App features->Bot` select the bot you created previously
-1. Select `Preview in Teams`
+```bash
+teams app create --name "Bot Message Extensions" --endpoint https://<your-devtunnel-domain>/api/messages --env .env
+```
 
-> Note. When using an Azure Bot resource, provide the ClientID instead of selecting an existing bot.
+For .NET (`dotnet/bot-message-extensions`):
+
+```bash
+teams app create --name "Bot Message Extensions" --endpoint https://<your-devtunnel-domain>/api/messages --env appsettings.json
+```
+
+This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your DevTunnels endpoint, generates and uploads the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
 
 ### Configure the App Manifest
 
-Ensure the `manifest.json` includes the `composeExtensions` section as shown below:
+Message extensions require a `composeExtensions` section in `manifest.json`. The Teams Developer CLI generates a baseline manifest, so add the search command and link-unfurling handler to the generated `manifest.json` before re-packaging and re-uploading the app (`teams app package` and `teams app update`):
 
 ```json
 "composeExtensions": [
@@ -116,81 +119,18 @@ Ensure the `manifest.json` includes the `composeExtensions` section as shown bel
 ],
 ```
 
-## Configure the new project to use the new Teams Bot Application
-
-For NodeJS and Python you will need a `.env` file with the next fields
-
-```
-CLIENT_ID=
-CLIENT_SECRET=
-TENANT_ID=
-```
-
-For dotnet you need to add these values to `appsettings.json` or `launchSettings.json` using the next syntax.
-
-appsettings.json
-
-```json
-"urls" : "http://localhost:3978",
-"Teams": {
-    "ClientID": "",
-    "ClientSecret": "",
-    "TenantId": ""
- },
-```
-
-Or to use Env Vars from the profile defined in `launchSettings.json` (using the Environment Configuration Provider)
-
-```json
- "teamsbot": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:3978",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Teams__TenantId": "YOUR_TenantId",
-        "Teams__ClientID": "YOUR_ClientId",
-        "Teams__ClientSecret": "YOUR_ClientSecret"
-      }
-    }
-```
-
-For Python, run the bot using pip:
-
-```bash
-pip install -e .
-python main.py
-```
-
-### Alternative: Using uv (Python)
-
-```bash
-uv sync
-uv run main.py
-```
-
-The bot will start listening on `http://localhost:3978`.
-
-## Pro Tip: Read the configuration settings using the Azure CLI
-
-To obtain the TenantId, ClientId and ClientSecret you can use the Azure CLI with:
-
-> Note. If you don't have access to an Azure Subscription you can still use the Azure CLI, make sure you login with `az login --allow-no-subscription`
-
-```
-az ad app credential reset --id $appId
-```
+Once provisioning and manifest configuration are complete, start your bot and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
-- Ensure your .env or appsettings file is setup correctly.
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors (not available in Teams Developer Portal).
+- Ensure your `.env` or `appsettings.json` file is set up correctly.
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors.
 
 ## Further Reading
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
 - [Message extensions overview](https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions)
 - [Search commands](https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/search-commands/define-search-command)
 - [Link unfurling](https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling)

--- a/samples/TeamsSDK/bot-message-extensions/README.md
+++ b/samples/TeamsSDK/bot-message-extensions/README.md
@@ -121,6 +121,8 @@ Message extensions require a `composeExtensions` section in `manifest.json`. The
 
 Once provisioning and manifest configuration are complete, start your bot and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive the CLI provisioning and manifest steps from natural language - your assistant runs the right commands, manages credentials, and guides you through bot registration end-to-end.
+
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
@@ -131,6 +133,7 @@ Once provisioning and manifest configuration are complete, start your bot and si
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language
 - [Message extensions overview](https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/what-are-messaging-extensions)
 - [Search commands](https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/search-commands/define-search-command)
 - [Link unfurling](https://learn.microsoft.com/en-us/microsoftteams/platform/messaging-extensions/how-to/link-unfurling)

--- a/samples/TeamsSDK/bot-message-extensions/README.md
+++ b/samples/TeamsSDK/bot-message-extensions/README.md
@@ -33,7 +33,7 @@ The extension supports the following capabilities:
 
 # How to run these samples
 
-You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project''s environment file, and started the bot against a public DevTunnels URL.
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project's environment file, and started the bot against a public DevTunnels URL.
 
 ## Run in the Teams Client
 
@@ -57,7 +57,7 @@ Take note of the URL shown after *Connect via browser:*
 
 ## Provision with the Teams Developer CLI
 
-The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project''s environment file in a single command.
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project's environment file in a single command.
 
 Sign in with your M365 account:
 

--- a/samples/TeamsSDK/bot-message-extensions/dotnet/bot-message-extensions/README.md
+++ b/samples/TeamsSDK/bot-message-extensions/dotnet/bot-message-extensions/README.md
@@ -20,4 +20,4 @@ This sample demonstrates a search-based messaging extension in Microsoft Teams t
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the Microsoft 365 Agents Playground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-message-extensions/nodejs/bot-message-extensions/README.md
+++ b/samples/TeamsSDK/bot-message-extensions/nodejs/bot-message-extensions/README.md
@@ -25,4 +25,4 @@ This sample demonstrates a search-based messaging extension in Microsoft Teams t
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/README.md
+++ b/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/README.md
@@ -4,7 +4,7 @@ This sample demonstrates a search-based messaging extension in Microsoft Teams t
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample

--- a/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/README.md
+++ b/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/README.md
@@ -4,7 +4,7 @@ This sample demonstrates a search-based messaging extension in Microsoft Teams t
 
 ## Prerequisites
 
-- [Python >=3.12, <3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample
@@ -34,4 +34,4 @@ python main.py
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the Microsoft 365 Agents Playground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/pyproject.toml
+++ b/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-message-extensions"
 version = "0.1.0"
 description = "This sample demonstrates a search-based messaging extension in Microsoft Teams that allows users to search Wikipedia articles."
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "python-dotenv>=1.2.2",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/pyproject.toml
+++ b/samples/TeamsSDK/bot-message-extensions/python/bot-message-extensions/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-message-extensions"
 version = "0.1.0"
 description = "This sample demonstrates a search-based messaging extension in Microsoft Teams that allows users to search Wikipedia articles."
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "python-dotenv>=1.2.2",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-quickstart/README.md
+++ b/samples/TeamsSDK/bot-quickstart/README.md
@@ -83,6 +83,8 @@ This single command creates a Microsoft Entra app registration, registers a Team
 
 Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive these CLI steps from natural language - your assistant runs the right commands, manages credentials, and guides you through bot registration end-to-end.
+
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
@@ -93,3 +95,4 @@ Once provisioning completes, start your bot - the sample will pick up the creden
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language

--- a/samples/TeamsSDK/bot-quickstart/README.md
+++ b/samples/TeamsSDK/bot-quickstart/README.md
@@ -8,14 +8,14 @@ This sample demonstrates how to handle various bot conversation events in Micros
 - [Sample Implementations](#sample-implementations)
 - [How to run these samples](#how-to-run-these-samples)
   - [Run in the Teams Client](#run-in-the-teams-client)
-- [Configure the new project to use the new Teams Bot Application](#configure-the-new-project-to-use-the-new-teams-bot-application)
-- [Pro Tip: Read the configuration settings using the Azure CLI](#pro-tip-read-the-configuration-settings-using-the-azure-cli)
+    - [Configure DevTunnels](#configure-devtunnels)
+  - [Provision with the Teams Developer CLI](#provision-with-the-teams-developer-cli)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
 ## Interaction with Bot
 
-![Conversation Bot](bot-quickstart.gif)
+![Bot Quickstart](bot-quickstart.gif)
 
 The bot responds to the following commands:
 
@@ -33,109 +33,63 @@ The bot responds to the following commands:
 
 # How to run these samples
 
-You can run these samples locally using:
-
-1. In the Teams Client after you have provisioned the Teams Application and configured the application with your local DevTunnels URL.
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project's environment file, and started the bot against a public DevTunnels URL.
 
 ## Run in the Teams Client
 
-To run these samples in the Teams Client, you need to provision your app in a M365 Tenant, and configure the app to your DevTunnels URL.
+To run these samples in the Teams Client, you need to provision your app in an M365 tenant and configure the app to your DevTunnels URL.
 
-1. Install the tool DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-2. Get Access to a M365 Developer Tenant https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started
-3. Create a Teams App with the Bot Feature in the Teams Developer Portal (in your tenant) https://dev.teams.microsoft.com
+1. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
+2. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
+3. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
 
 ### Configure DevTunnels
 
-Create a persistent tunnel for the port 3978 with anonymous access
+Create a persistent tunnel for port 3978 with anonymous access:
 
-```
-devtunnel create -a my-tunnel  
-devtunnel port create -p 3978  my-tunnel 
-devtunnel host  my-tunnel
+```bash
+devtunnel create -a my-tunnel
+devtunnel port create -p 3978 my-tunnel
+devtunnel host my-tunnel
 ```
 
 Take note of the URL shown after *Connect via browser:*
 
-### Provisioning the Teams Application
+## Provision with the Teams Developer CLI
 
-Navigate to the Teams Developer Portal http://dev.teams.microsoft.com
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project's environment file in a single command.
 
-#### Create a new Bot resource
+Sign in with your M365 account:
 
-1. Navigate to `Tools->Bot management`, and add a `New bot`
-1. In Configure, paste the Endpoint address from devtunnels and append `/api/messages`
-1. In Client secrets, create a new secret and save it for later
-
-> Note. If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
-
-#### Create a new Teams App
-
-1. Navigate to `Apps` and create a `New App`
-1. Fill the required values in Basic information (short and long name, short and long description and App URLs)
-1. In `App features->Bot` select the bot you created previously
-1. Select `Preview in Teams`
-
-> Note. When using an Azure Bot resource, provide the ClientID instead of selecting an existing bot.
-
-## Configure the new project to use the new Teams Bot Application
-
-For NodeJS and Python you will need a `.env` file with the next fields
-
-```
-TENANT_ID=
-CLIENT_ID=
-CLIENT_SECRET=
+```bash
+teams login
 ```
 
-For dotnet you need to add these values to `appsettings.json` or `launchSettings.json` using the next syntax.
+From the language-specific sample directory you want to run, provision the app and credentials.
 
-appsettings.json
+For Node.js and Python (`nodejs/<sample>` or `python/<sample>`):
 
-
-```json
-"urls" : "http://localhost:3978",
-"Teams": {
-    "ClientID": "",
-    "ClientSecret": "",
-    "TenantId": ""
-  },
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env .env
 ```
 
-Or to use Env Vars from the profile defined in `launchSettings.json` (using the Environment Configuration Provider)
+For .NET (`dotnet/<sample>`):
 
-```json
- "teamsbot": {
-      "commandName": "Project",
-      "dotnetRunMessages": true,
-      "launchBrowser": false,
-      "applicationUrl": "http://localhost:3978",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Teams__TenantId": "YOUR_TenantId",
-        "Teams__ClientID": "YOUR_ClientId",
-        "Teams__ClientSecret": "YOUR_ClientSecret"
-      }
-    }
+```bash
+teams app create --name "<App Name>" --endpoint https://<your-devtunnel-domain>/api/messages --env appsettings.json
 ```
 
-## Pro Tip: Read the configuration settings using the Azure CLI
+This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your DevTunnels endpoint, generates and uploads the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
 
-To obtain the TenantId, ClientId and ClientSecret you can use the Azure CLI with:
-
-> Note. If you don't have access to an Azure Subscription you can still use the Azure CLI, make sure you login with `az login --allow-no-subscription` 
-
-```
-az ad app credential reset --id $appId
-```
+Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
-- Ensure your .env or appsettings file is setup correctly.
-- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors (not available in Teams Developer Portal).
-
+- Ensure your `.env` or `appsettings.json` file is set up correctly.
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors.
 
 ## Further Reading
 
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)

--- a/samples/TeamsSDK/bot-quickstart/dotnet/bot-quickstart/README.md
+++ b/samples/TeamsSDK/bot-quickstart/dotnet/bot-quickstart/README.md
@@ -20,4 +20,4 @@ This sample demonstrates a Bot Quickstart for Microsoft Teams using .NET and ASP
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-quickstart/nodejs/bot-quickstart/README.md
+++ b/samples/TeamsSDK/bot-quickstart/nodejs/bot-quickstart/README.md
@@ -25,4 +25,4 @@ This sample demonstrates a basic Teams Conversation Bot for Microsoft Teams usin
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/README.md
+++ b/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/README.md
@@ -4,7 +4,7 @@ This sample demonstrates a Bot Quickstart for Microsoft Teams using Python.
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample

--- a/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/README.md
+++ b/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/README.md
@@ -4,7 +4,7 @@ This sample demonstrates a Bot Quickstart for Microsoft Teams using Python.
 
 ## Prerequisites
 
-- [Python >=3.12, <3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample
@@ -34,4 +34,4 @@ python main.py
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/pyproject.toml
+++ b/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-quickstart"
 version = "0.1.0"
 description = "This sample demonstrates a Bot Quickstart for Microsoft Teams using Python."
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "python-dotenv>=1.0",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/pyproject.toml
+++ b/samples/TeamsSDK/bot-quickstart/python/bot-quickstart/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-quickstart"
 version = "0.1.0"
 description = "This sample demonstrates a Bot Quickstart for Microsoft Teams using Python."
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "python-dotenv>=1.0",
     "microsoft-teams-apps==2.0.0",

--- a/samples/TeamsSDK/bot-task-modules/README.md
+++ b/samples/TeamsSDK/bot-task-modules/README.md
@@ -40,8 +40,8 @@ The bot supports the following functionalities:
 ### 3. Multistep Form Task Module
 
 - Opens a two-step Adaptive Card dialog within a single task module session
-- **Step 1** collects the user''s name and advances to the next step on submit
-- **Step 2** carries forward the name from step 1 and collects the user''s email address
+- **Step 1** collects the user's name and advances to the next step on submit
+- **Step 2** carries forward the name from step 1 and collects the user's email address
 - On final submission, the bot sends a personalized confirmation message (`Hi {name}, thanks for submitting! Your email is {email}`)
 - Demonstrates chaining task module responses using `task/continue` to transition between steps
 - Shows how to pass data between steps using the Adaptive Card `Action.Submit` `data` payload
@@ -56,7 +56,7 @@ The bot supports the following functionalities:
 
 # How to run these samples
 
-You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project''s environment file, and started the bot against a public DevTunnels URL.
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project's environment file, and started the bot against a public DevTunnels URL.
 
 ## Run in the Teams Client
 
@@ -80,7 +80,7 @@ Take note of the URL shown after *Connect via browser:*
 
 ## Provision with the Teams Developer CLI
 
-The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project''s environment file in a single command.
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project's environment file in a single command.
 
 Sign in with your M365 account:
 

--- a/samples/TeamsSDK/bot-task-modules/README.md
+++ b/samples/TeamsSDK/bot-task-modules/README.md
@@ -12,9 +12,7 @@ This sample demonstrates how to use task modules (dialogs) in Microsoft Teams us
 - [How to run these samples](#how-to-run-these-samples)
   - [Run in the Teams Client](#run-in-the-teams-client)
     - [Configure DevTunnels](#configure-devtunnels)
-    - [Provisioning the Teams Application](#provisioning-the-teams-application)
-  - [Configure the new project to use the new Teams Bot Application](#configure-the-new-project-to-use-the-new-teams-bot-application)
-  - [Pro Tip: Read the configuration settings using the Azure CLI](#pro-tip-read-the-configuration-settings-using-the-azure-cli)
+  - [Provision with the Teams Developer CLI](#provision-with-the-teams-developer-cli)
 - [Troubleshooting](#troubleshooting)
 - [Further Reading](#further-reading)
 
@@ -42,8 +40,8 @@ The bot supports the following functionalities:
 ### 3. Multistep Form Task Module
 
 - Opens a two-step Adaptive Card dialog within a single task module session
-- **Step 1** collects the user's name and advances to the next step on submit
-- **Step 2** carries forward the name from step 1 and collects the user's email address
+- **Step 1** collects the user''s name and advances to the next step on submit
+- **Step 2** carries forward the name from step 1 and collects the user''s email address
 - On final submission, the bot sends a personalized confirmation message (`Hi {name}, thanks for submitting! Your email is {email}`)
 - Demonstrates chaining task module responses using `task/continue` to transition between steps
 - Shows how to pass data between steps using the Adaptive Card `Action.Submit` `data` payload
@@ -56,79 +54,69 @@ The bot supports the following functionalities:
 | Typescript | Node.js | [nodejs/bot-task-modules](nodejs/bot-task-modules/README.md) |
 | Python | Python | [python/bot-task-modules](python/bot-task-modules/README.md) |
 
-## How to run these samples
+# How to run these samples
 
-### Run in the Teams Client
+You can run these samples locally in the Teams Client after you have provisioned the Teams app, written its credentials into your project''s environment file, and started the bot against a public DevTunnels URL.
 
-In the Teams client after you have provisioned the Teams Application, configured the application with your local DevTunnels URL, and sideloaded the app.
+## Run in the Teams Client
 
-1. Install the tool DevTunnels https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started
-2. Get Access to a M365 Developer Tenant https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started
-3. Create a Teams App with the Bot Feature in the Teams Developer Portal (in your tenant) https://dev.teams.microsoft.com
+To run these samples in the Teams Client, you need to provision your app in an M365 tenant and configure the app to your DevTunnels URL.
 
-#### Configure DevTunnels
+1. Install the [DevTunnels CLI](https://learn.microsoft.com/en-us/azure/developer/dev-tunnels/get-started)
+2. Get access to an [M365 Developer Tenant](https://learn.microsoft.com/en-us/office/developer-program/microsoft-365-developer-program-get-started)
+3. Install the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/installation): `npm install -g @microsoft/teams.cli`
 
-Create a persistent tunnel for the port 3978 with anonymous access
+### Configure DevTunnels
+
+Create a persistent tunnel for port 3978 with anonymous access:
 
 ```bash
-devtunnel create my-tunnel --allow-anonymous
-devtunnel port create my-tunnel -p 3978
+devtunnel create -a my-tunnel
+devtunnel port create -p 3978 my-tunnel
 devtunnel host my-tunnel
 ```
 
-Take note of the URL shown after Connect via browser:
+Take note of the URL shown after *Connect via browser:*
 
-#### Provisioning the Teams Application
+## Provision with the Teams Developer CLI
 
-Navigate to the Teams Developer Portal http://dev.teams.microsoft.com
+The [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/) provisions your Microsoft Entra app, Teams-managed bot registration, Teams app manifest, and writes the credentials directly into your project''s environment file in a single command.
 
-##### Create a new Bot resource
-
-1. Navigate to `Tools->Bot management`, and add a `New bot`
-2. In Configure, paste the Endpoint address from devtunnels and append `/api/messages`
-3. In Client secrets, create a new secret and save it for later
-
-> **Note.** If you have access to an Azure Subscription in the same Tenant, you can also create the Azure Bot resource ([learn more](https://learn.microsoft.com/en-us/azure/bot-service/abs-quickstart?view=azure-bot-service-4.0&tabs=singletenant)).
-
-##### Create a new Teams App
-
-1. Navigate to `Apps` and create a `New App`
-2. Fill the required values in Basic information (short and long name, short and long description and App URLs)
-3. In `App features->Bot` select the bot you created previously
-4. Select `Preview in Teams` to sideload the app
-
-> **Note.** When using an Azure Bot resource, provide the ClientID instead of selecting an existing bot.
-
-### Configure the new project to use the new Teams Bot Application
-
-For NodeJS you will need a `.env` file with the next fields:
-
-```
-TENANT_ID=
-CLIENT_ID=
-CLIENT_SECRET=
-```
-
-### Pro Tip: Read the configuration settings using the Azure CLI
-
-To obtain the TenantId, ClientId and SecretId you can use the Azure CLI with:
-
-> **Note.** If you don't have access to an Azure Subscription you can still use the Azure CLI, make sure you login with `az login --allow-no-subscription`
+Sign in with your M365 account:
 
 ```bash
-az ad app credential reset --id $appId
+teams login
 ```
+
+From the language-specific sample directory you want to run, provision the app and credentials.
+
+For Node.js and Python (`nodejs/bot-task-modules` or `python/bot-task-modules`):
+
+```bash
+teams app create --name "Bot Task Modules" --endpoint https://<your-devtunnel-domain>/api/messages --env .env
+```
+
+For .NET (`dotnet/bot-task-modules`):
+
+```bash
+teams app create --name "Bot Task Modules" --endpoint https://<your-devtunnel-domain>/api/messages --env appsettings.json
+```
+
+This single command creates a Microsoft Entra app registration, registers a Teams-managed bot pointing at your DevTunnels endpoint, generates and uploads the Teams app manifest, and writes `CLIENT_ID`, `CLIENT_SECRET`, and `TENANT_ID` into the environment file you specified (PascalCase keys under a `Teams` section for `appsettings.json`).
+
+Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
-- Ensure your .env or appsettings file is setup correctly.
+- Ensure your `.env` or `appsettings.json` file is set up correctly.
 - Verify that the task module URL (for custom form) is properly configured and accessible.
 - For custom form issues, ensure your bot endpoint is serving static files correctly.
-- The Azure Bot Service (ABS) Channels UI is very useful to see any errors in the endpoint (only available in ABS, not in Teams Developer Portal).
+- Use the Channels UI in Azure Bot Service in the Azure Portal to see detailed endpoint errors.
 
 ## Further Reading
 
 - [Task Modules in Microsoft Teams](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/what-are-task-modules)
 - [Invoke and dismiss task modules](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/task-modules/invoking-task-modules)
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
+- [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)

--- a/samples/TeamsSDK/bot-task-modules/README.md
+++ b/samples/TeamsSDK/bot-task-modules/README.md
@@ -106,6 +106,8 @@ This single command creates a Microsoft Entra app registration, registers a Team
 
 Once provisioning completes, start your bot - the sample will pick up the credentials automatically - and sideload the app from the prompt in Teams. See the [Teams Developer CLI documentation](https://microsoft.github.io/teams-sdk/cli/) for the full command reference.
 
+> **Tip**: Using an AI coding assistant (GitHub Copilot CLI, Claude Code, Cursor, VS Code)? Install the [`teams-dev` agent skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) to drive these CLI steps from natural language - your assistant runs the right commands, manages credentials, and guides you through bot registration end-to-end.
+
 ## Troubleshooting
 
 - If Teams cannot communicate with your bot, verify your DevTunnels URL is reachable.
@@ -120,3 +122,4 @@ Once provisioning completes, start your bot - the sample will pick up the creden
 - [Invoke and dismiss task modules](https://learn.microsoft.com/en-us/microsoftteams/platform/task-modules-and-cards/task-modules/invoking-task-modules)
 - [Microsoft Teams SDK Documentation](https://learn.microsoft.com/microsoftteams/platform/)
 - [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)
+- [`teams-dev` Agent Skill](https://microsoft.github.io/teams-sdk/developer-tools/agent-skills) - AI coding assistant skill that drives the Teams Developer CLI via natural language

--- a/samples/TeamsSDK/bot-task-modules/dotnet/bot-task-modules/README.md
+++ b/samples/TeamsSDK/bot-task-modules/dotnet/bot-task-modules/README.md
@@ -20,4 +20,4 @@ This sample demonstrates Task Modules for Microsoft Teams using .NET and ASP.NET
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-task-modules/nodejs/bot-task-modules/README.md
+++ b/samples/TeamsSDK/bot-task-modules/nodejs/bot-task-modules/README.md
@@ -22,4 +22,4 @@ This sample demonstrates Task Modules for Microsoft Teams using TypeScript.
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/README.md
+++ b/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/README.md
@@ -4,7 +4,7 @@ This sample demonstrates Task Modules for Microsoft Teams using Python.
 
 ## Prerequisites
 
-- [Python >=3.12](https://www.python.org/downloads/)
+- [Python >=3.11](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample

--- a/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/README.md
+++ b/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/README.md
@@ -4,7 +4,7 @@ This sample demonstrates Task Modules for Microsoft Teams using Python.
 
 ## Prerequisites
 
-- [Python >=3.12, <3.15](https://www.python.org/downloads/)
+- [Python >=3.12](https://www.python.org/downloads/)
 - pip (recommended) or [uv](https://docs.astral.sh/uv/)
 
 ## Run the sample
@@ -34,4 +34,4 @@ python main.py
 
 The bot will start listening on `http://localhost:3978`.
 
-Refer to the main [README.md](../../README.md) to interact with your bot in the agentsplayground or in Teams.
+Once the bot is running, follow the main [README.md](../../README.md) to provision your app and side-load it into Teams using the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/).

--- a/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/pyproject.toml
+++ b/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-task-modules"
 version = "0.1.0"
 description = "This sample demonstrates Task Modules in Microsoft Teams using the Teams SDK for Python."
 readme = "README.md"
-requires-python = ">=3.12,<3.15"
+requires-python = ">=3.12,<4.0"
 dependencies = [
     "microsoft-teams-apps==2.0.0",
     "microsoft-teams-api==2.0.0",

--- a/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/pyproject.toml
+++ b/samples/TeamsSDK/bot-task-modules/python/bot-task-modules/pyproject.toml
@@ -3,7 +3,7 @@ name = "bot-task-modules"
 version = "0.1.0"
 description = "This sample demonstrates Task Modules in Microsoft Teams using the Teams SDK for Python."
 readme = "README.md"
-requires-python = ">=3.12,<4.0"
+requires-python = ">=3.11,<4.0"
 dependencies = [
     "microsoft-teams-apps==2.0.0",
     "microsoft-teams-api==2.0.0",


### PR DESCRIPTION
## Summary

Two related documentation changes for the samples under `samples/TeamsSDK`:

1. **Relax the Python upper bound** to match the upcoming change in [microsoft/teams.py#446](https://github.com/microsoft/teams.py/pull/446) — `requires-python` goes from `>=3.12,<3.15` to `>=3.12,<4.0` across all 8 Python samples, and the prerequisite link in each child Python README drops the upper bound (now just `Python >=3.12`).
2. **Switch the recommended provisioning path to the [Teams Developer CLI](https://microsoft.github.io/teams-sdk/cli/)** 

TODO:
- Per-sample `uv.lock` files were not regenerated. They will refresh on the next `uv lock` run.
