### PR TITLE
Remove YAML front matter from archived sample READMEs

### DIFF
--- a/samples/TeamsSDK/Archived/agent-knowledge-hub/csharp/README.md
+++ b/samples/TeamsSDK/Archived/agent-knowledge-hub/csharp/README.md
@@ -1,18 +1,3 @@
----
-page_type: sample
-description: Contoso Knowledge Hub - AI Academic & Career Guidance Agent.
-products:
-- office-teams
-- office
-- office-365
-languages:
-- csharp
-extensions:
- contentType: samples
- createdDate: "21-10-2025 13:38:26"
-urlFragment: officedev-microsoft-teams-samples-agent-knowledge-hub-csharp
----
-
 # Contoso Knowledge Hub - AI Academic & Career Guidance Agent
 Contoso Knowledge Hub is an intelligent guidance agent built on the Teams SDK, designed to empower students in their academic and career journeys. It offers personalized course recommendations, career-aligned planning, institutional insights, and expert-endorsed AI course recommendations.
 

--- a/samples/TeamsSDK/Archived/agent-knowledge-hub/nodejs/README.md
+++ b/samples/TeamsSDK/Archived/agent-knowledge-hub/nodejs/README.md
@@ -1,18 +1,3 @@
----
-page_type: sample
-description: Contoso Knowledge Hub - AI Academic & Career Guidance Agent
-products:
-- office-teams
-- office
-- office-365
-languages:
-- nodejs
-extensions:
- contentType: samples
- createdDate: "10/21/2025 01:38:25 PM"
-urlFragment: officedev-microsoft-teams-samples-agent-knowledge-hub-nodejs
----
-
 # Contoso Knowledge Hub - AI Academic & Career Guidance Agent
 Contoso Knowledge Hub is an intelligent guidance agent built on the Teams SDK, designed to empower students in their academic and career journeys. It offers personalized course recommendations, career-aligned planning, institutional insights, and expert-endorsed AI course recommendations.
 

--- a/samples/TeamsSDK/Archived/agent-knowledge-hub/python/README.md
+++ b/samples/TeamsSDK/Archived/agent-knowledge-hub/python/README.md
@@ -1,18 +1,3 @@
----
-page_type: sample
-description: Contoso Knowledge Hub - AI Academic & Career Guidance Agent
-products:
-- office-teams
-- office
-- office-365
-languages:
-- Python
-extensions:
- contentType: samples
- createdDate: "10/21/2025 01:38:25 PM"
-urlFragment: officedev-microsoft-teams-samples-agent-knowledge-hub-python
----
-
 # Contoso Knowledge Hub - AI Academic & Career Guidance Agent
 
 This sample demonstrates an AI-powered Academic Agent built with the **Microsoft Teams SDK for Python**. The bot provides comprehensive educational support, career guidance, and course recommendations using Azure OpenAI.


### PR DESCRIPTION
## Summary
- Removed the YAML front matter from the README.md files in archived samples.
- No other README content was modified.

## Purpose
Remove the YAML front matter from archived sample README files so they are no longer listed on the Microsoft Learn Samples site while keeping the samples available in the GitHub repository.