### PR TITLE
Security hardening for connector-todo-notification sample (C# and Nod…

### DIFF
--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Controllers/ConnectorController.cs
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Controllers/ConnectorController.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web;
 using TeamsToDoAppConnector.Models;
 using TeamsToDoAppConnector.Models.Configuration;
 using TeamsToDoAppConnector.Repository;
@@ -10,6 +12,7 @@ namespace TeamsToDoAppConnector.Controllers
     /// <summary>
     /// Represents the controller responsible for setting up the connector.
     /// </summary>
+    [Authorize]
     public class ConnectorController : Controller
     {
 
@@ -44,13 +47,29 @@ namespace TeamsToDoAppConnector.Controllers
             }
             else
             {
-                var subscription = SubscriptionRepository.Subscriptions.Where(sub => sub.WebHookUri == webhookInfo.WebhookUrl).FirstOrDefault();
+                // Validate the destination before storing or calling it to prevent SSRF (CWE-918).
+                if (!WebhookValidator.IsValid(webhookInfo.WebhookUrl, appSettings.Value.AllowedWebhookHostSuffixes, out _))
+                {
+                    return RedirectToAction("Error");
+                }
+
+                // Bind the webhook to the authenticated connector context (owner + tenant).
+                var ownerObjectId = User.GetObjectId();
+                var ownerTenantId = User.GetTenantId();
+
+                var subscription = SubscriptionRepository.Subscriptions
+                    .Where(sub => sub.WebHookUri == webhookInfo.WebhookUrl
+                        && sub.OwnerObjectId == ownerObjectId
+                        && sub.OwnerTenantId == ownerTenantId)
+                    .FirstOrDefault();
                 if (subscription == null)
                 {
                     Subscription newSubscription = new Subscription
                     {
                         WebHookUri = webhookInfo.WebhookUrl,
-                        EventType = webhookInfo.EventType
+                        EventType = webhookInfo.EventType,
+                        OwnerObjectId = ownerObjectId,
+                        OwnerTenantId = ownerTenantId
                     };
 
                     // Save the subscription so that it can be used to push data to the registered channels.
@@ -62,7 +81,7 @@ namespace TeamsToDoAppConnector.Controllers
                     subscription.EventType = webhookInfo.EventType;
                 }
 
-                await TaskHelper.PostWelcomeMessage(webhookInfo.WebhookUrl, appSettings.Value.BaseUrl);
+                await TaskHelper.PostWelcomeMessage(webhookInfo.WebhookUrl, appSettings.Value.BaseUrl, appSettings.Value.AllowedWebhookHostSuffixes);
 
                 return View();
             }

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Controllers/TaskController.cs
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Controllers/TaskController.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.AspNetCore.Mvc;
+﻿using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
+using Microsoft.Identity.Web;
 using TeamsToDoAppConnector.Models;
 using TeamsToDoAppConnector.Models.Configuration;
 using TeamsToDoAppConnector.Repository;
@@ -11,6 +13,7 @@ namespace TeamsToDoAppConnector.Controllers
     /// Represents the controller which handles tasks create, update. 
     /// This class also sends push notification to the channels.
     /// </summary>
+    [Authorize]
     public class TaskController : Controller
     {
 
@@ -44,10 +47,13 @@ namespace TeamsToDoAppConnector.Controllers
             item.Guid = Guid.NewGuid().ToString();
             TaskRepository.Tasks.Add(item);
 
-            // Loop through subscriptions and notify each channel that task is created.
-            foreach (var sub in SubscriptionRepository.Subscriptions)
+            // Only notify webhooks registered by the current authenticated connector context.
+            var ownerObjectId = User.GetObjectId();
+            var ownerTenantId = User.GetTenantId();
+            foreach (var sub in SubscriptionRepository.Subscriptions
+                .Where(s => s.OwnerObjectId == ownerObjectId && s.OwnerTenantId == ownerTenantId))
             {
-                await TaskHelper.PostTaskNotification(sub.WebHookUri, item, "Created",appSettings.Value.BaseUrl);
+                await TaskHelper.PostTaskNotification(sub.WebHookUri, item, "Created", appSettings.Value.BaseUrl, appSettings.Value.AllowedWebhookHostSuffixes);
             }
 
             return RedirectToAction("Detail", new { id = item.Guid });
@@ -64,24 +70,29 @@ namespace TeamsToDoAppConnector.Controllers
         [HttpPost]
         public async Task Update([FromBody]Request request, string id)
         {
-            //Task<HttpResponseMessage>
             var task = TaskRepository.Tasks.First(t => t.Guid == id);
             task.Title = request.Title;
 
             string json = TaskHelper.GetConnectorCardJson(task, "Updated", appSettings.Value.BaseUrl);
 
+            // Only notify webhooks registered by the current authenticated connector context.
+            var ownerObjectId = User.GetObjectId();
+            var ownerTenantId = User.GetTenantId();
+            foreach (var sub in SubscriptionRepository.Subscriptions
+                .Where(s => s.EventType == EventType.Update
+                    && s.OwnerObjectId == ownerObjectId
+                    && s.OwnerTenantId == ownerTenantId))
+            {
+                await TaskHelper.PostTaskNotification(sub.WebHookUri, task, "Updated", appSettings.Value.BaseUrl, appSettings.Value.AllowedWebhookHostSuffixes);
+            }
+
+            // Write the response after notifications so setting headers/status is valid.
             Response.Clear();
             Response.ContentType = "application/json; charset=utf-8";
-            Response.Headers.Add("CARD-ACTION-STATUS", "The task is uppdate.");
-            Response.Headers.Add("CARD-UPDATE-IN-BODY", "true");
-            Response.WriteAsync(json);
+            Response.Headers["CARD-ACTION-STATUS"] = "The task is updated.";
+            Response.Headers["CARD-UPDATE-IN-BODY"] = "true";
             Response.StatusCode = StatusCodes.Status200OK;
-            
-            // Send Task updated notification to all Subscriptions.
-            foreach (var sub in SubscriptionRepository.Subscriptions.Where(s => s.EventType == EventType.Update))
-            {
-                await TaskHelper.PostTaskNotification(sub.WebHookUri, task, "Updated", appSettings.Value.BaseUrl);
-            }
+            await Response.WriteAsync(json);
         }
     }
 }

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Models/Configuration/AppSettings.cs
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Models/Configuration/AppSettings.cs
@@ -16,5 +16,12 @@
         /// Gets or sets Tenant Id for single-tenant configuration.
         /// </summary>
         public string? TenantId { get; set; }
+
+        /// <summary>
+        /// Host suffixes that a webhook destination is allowed to target. Used to
+        /// prevent Server-Side Request Forgery (SSRF) by restricting outbound calls
+        /// to trusted Microsoft Teams / Office 365 connector endpoints only.
+        /// </summary>
+        public string[]? AllowedWebhookHostSuffixes { get; set; }
     }
 }

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Models/Subscription.cs
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Models/Subscription.cs
@@ -7,6 +7,10 @@
     {
         public string? WebHookUri { get; set; }
         public EventType EventType { get; set; }
+
+        // Identity of the Entra ID user/connector context that registered this webhook.
+        public string? OwnerObjectId { get; set; }
+        public string? OwnerTenantId { get; set; }
     }
 
     /// <summary>

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Program.cs
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Program.cs
@@ -1,9 +1,25 @@
 using TeamsToDoAppConnector.Models.Configuration;
+using Microsoft.AspNetCore.Authentication.OpenIdConnect;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.Identity.Web;
+using Microsoft.Identity.Web.UI;
 
 var builder = WebApplication.CreateBuilder(args);
 
+// Require an authenticated Microsoft Entra ID user before any endpoint runs.
+builder.Services.AddAuthentication(OpenIdConnectDefaults.AuthenticationScheme)
+    .AddMicrosoftIdentityWebApp(builder.Configuration.GetSection("AzureAd"));
+
 // Add services to the container.
-builder.Services.AddControllersWithViews();
+builder.Services.AddControllersWithViews(options =>
+{
+    // Deny anonymous access globally; individual actions can opt out with [AllowAnonymous].
+    var policy = new AuthorizationPolicyBuilder()
+        .RequireAuthenticatedUser()
+        .Build();
+    options.Filters.Add(new AuthorizeFilter(policy));
+}).AddMicrosoftIdentityUI();
 
 builder.Services.AddHttpClient();
 
@@ -14,6 +30,7 @@ builder.Services.AddOptions<AppSettings>()
     botOptions.BaseUrl = configuration.GetValue<string>("BaseUrl");
     botOptions.ConnectorAppId = configuration.GetValue<string>("ConnectorAppId");
     botOptions.TenantId = configuration.GetValue<string>("TenantId");
+    botOptions.AllowedWebhookHostSuffixes = configuration.GetSection("AllowedWebhookHostSuffixes").Get<string[]>();
 });
 
 var app = builder.Build();
@@ -29,8 +46,10 @@ app.UseStaticFiles();
 
 app.UseRouting();
 
+app.UseAuthentication();
 app.UseAuthorization();
 
+app.MapControllers();
 app.MapDefaultControllerRoute();
 
 app.Run();

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/README.md
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/README.md
@@ -2,6 +2,12 @@
 
 This sample provides a comprehensive guide to building an Office 365 Connector that sends task notifications to a Microsoft Teams channel. The app simulates a task management system where users can create, view, and update tasks, showcasing how to send notifications through connectors to enhance productivity in Teams.
 
+> [!IMPORTANT]
+> **Security notice**
+> * **Do not expose this sample anonymously.** All setup and task endpoints require Microsoft Entra ID sign-in; you must configure the `AzureAd` section in `appsettings.json` (`ClientId`, `TenantId`, `ClientSecret`) before running. Never deploy it as a public, unauthenticated endpoint.
+> * **Webhook destinations are restricted.** Registered webhook URLs are accepted only when they use HTTPS and match the `AllowedWebhookHostSuffixes` allow-list, and are blocked when they resolve to loopback, private (RFC1918), link-local, or other reserved addresses. This prevents Server-Side Request Forgery (SSRF). Update the allow-list to match your own connector endpoints.
+> * Each registered webhook is bound to the authenticated user/tenant that created it, and notifications are sent only to webhooks owned by the current caller's context.
+
 ## Included Features
 * Connectors
 

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/TeamsToDoAppConnector.csproj
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/TeamsToDoAppConnector.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="35.6.5" />
+    <PackageReference Include="Microsoft.Identity.Web" Version="4.14.2" />
+    <PackageReference Include="Microsoft.Identity.Web.UI" Version="4.14.2" />
   </ItemGroup>
 
 </Project>

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Utils/TaskHelper.cs
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Utils/TaskHelper.cs
@@ -18,13 +18,13 @@ namespace TeamsToDoAppConnector.Utils
             };
         }
 
-        public static async Task PostTaskNotification(string webhook, TaskItem item, string title, string baseUrl)
+        public static async Task PostTaskNotification(string webhook, TaskItem item, string title, string baseUrl, string[]? allowedHostSuffixes)
         {
             string cardJson = GetConnectorCardJson(item, title, baseUrl);
-            await PostCardAsync(webhook, cardJson);
+            await PostCardAsync(webhook, cardJson, allowedHostSuffixes);
         }
 
-        public static async Task PostWelcomeMessage(string webhookUrl, string baseUrl)
+        public static async Task PostWelcomeMessage(string webhookUrl, string baseUrl, string[]? allowedHostSuffixes)
         {
             string cardJson = @"{
             ""@type"": ""MessageCard"",
@@ -33,12 +33,20 @@ namespace TeamsToDoAppConnector.Utils
                 ""activityTitle"": ""Welcome Message"",
                 ""text"": ""Teams ToDo connector has been set up. We will send you notification whenever new task is added in [Task Manager Portal](" + baseUrl + "/task/create" + @").""}]}";
 
-            await PostCardAsync(webhookUrl, cardJson);
+            await PostCardAsync(webhookUrl, cardJson, allowedHostSuffixes);
         }
 
-        private static async Task PostCardAsync(string webhook, string cardJson)
+        private static async Task PostCardAsync(string webhook, string cardJson, string[]? allowedHostSuffixes)
         {
-            using HttpClient client = new HttpClient();
+            // Re-validate the destination immediately before the outbound call (defense in depth against SSRF).
+            if (!WebhookValidator.IsValid(webhook, allowedHostSuffixes, out _))
+            {
+                return;
+            }
+
+            // Disable automatic redirects so a trusted host cannot bounce the request to an internal target.
+            using var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            using HttpClient client = new HttpClient(handler);
             client.DefaultRequestHeaders.Accept.Add(new MediaTypeWithQualityHeaderValue("application/json"));
             var content = new StringContent(cardJson, System.Text.Encoding.UTF8, "application/json");
             using var response = await client.PostAsync(webhook, content);

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Utils/WebhookValidator.cs
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/Utils/WebhookValidator.cs
@@ -1,0 +1,191 @@
+using System.Net;
+using System.Net.Sockets;
+
+namespace TeamsToDoAppConnector.Utils
+{
+    /// <summary>
+    /// Validates webhook destinations before they are stored or called, to prevent
+    /// Server-Side Request Forgery (SSRF, CWE-918). A destination is accepted only when
+    /// it is an absolute HTTPS URL, its host matches a configured allow-list of trusted
+    /// Microsoft connector endpoints, and none of the host's resolved IP addresses fall
+    /// into loopback, private, link-local, or other special-use ranges.
+    /// </summary>
+    public static class WebhookValidator
+    {
+        /// <summary>
+        /// Returns true only when the supplied webhook URL is safe to call.
+        /// </summary>
+        /// <param name="webhookUrl">The caller-supplied webhook destination.</param>
+        /// <param name="allowedHostSuffixes">Configured trusted host suffixes (e.g. ".webhook.office.com").</param>
+        /// <param name="failureReason">Human readable reason when validation fails.</param>
+        public static bool IsValid(string? webhookUrl, string[]? allowedHostSuffixes, out string failureReason)
+        {
+            failureReason = string.Empty;
+
+            if (string.IsNullOrWhiteSpace(webhookUrl))
+            {
+                failureReason = "Webhook URL is empty.";
+                return false;
+            }
+
+            if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out Uri? uri))
+            {
+                failureReason = "Webhook URL is not a valid absolute URL.";
+                return false;
+            }
+
+            // Only HTTPS is permitted; this blocks http, file, gopher, etc.
+            if (!string.Equals(uri.Scheme, Uri.UriSchemeHttps, StringComparison.OrdinalIgnoreCase))
+            {
+                failureReason = "Webhook URL must use the https scheme.";
+                return false;
+            }
+
+            // Reject embedded credentials (user:pass@host).
+            if (!string.IsNullOrEmpty(uri.UserInfo))
+            {
+                failureReason = "Webhook URL must not contain user information.";
+                return false;
+            }
+
+            if (!IsHostAllowed(uri.Host, allowedHostSuffixes))
+            {
+                failureReason = "Webhook host is not in the allow-list of trusted connector endpoints.";
+                return false;
+            }
+
+            // Resolve the host and ensure no address points at an internal/special-use range.
+            IPAddress[] addresses;
+            try
+            {
+                if (IPAddress.TryParse(uri.Host, out IPAddress? literal))
+                {
+                    addresses = new[] { literal };
+                }
+                else
+                {
+                    addresses = Dns.GetHostAddresses(uri.Host);
+                }
+            }
+            catch (SocketException)
+            {
+                failureReason = "Webhook host could not be resolved.";
+                return false;
+            }
+
+            if (addresses == null || addresses.Length == 0)
+            {
+                failureReason = "Webhook host did not resolve to any address.";
+                return false;
+            }
+
+            foreach (var address in addresses)
+            {
+                if (IsPrivateOrReserved(address))
+                {
+                    failureReason = "Webhook host resolves to a private, loopback, or reserved address.";
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        private static bool IsHostAllowed(string host, string[]? allowedHostSuffixes)
+        {
+            if (allowedHostSuffixes == null || allowedHostSuffixes.Length == 0)
+            {
+                // Fail closed: without a configured allow-list nothing is trusted.
+                return false;
+            }
+
+            foreach (var suffix in allowedHostSuffixes)
+            {
+                if (string.IsNullOrWhiteSpace(suffix))
+                {
+                    continue;
+                }
+
+                var normalized = suffix.Trim();
+                if (host.Equals(normalized.TrimStart('.'), StringComparison.OrdinalIgnoreCase) ||
+                    host.EndsWith(normalized.StartsWith('.') ? normalized : "." + normalized, StringComparison.OrdinalIgnoreCase))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static bool IsPrivateOrReserved(IPAddress address)
+        {
+            if (address.IsIPv4MappedToIPv6)
+            {
+                address = address.MapToIPv4();
+            }
+
+            if (IPAddress.IsLoopback(address))
+            {
+                return true;
+            }
+
+            if (address.AddressFamily == AddressFamily.InterNetwork)
+            {
+                byte[] bytes = address.GetAddressBytes();
+
+                // 0.0.0.0/8 (unspecified/current network)
+                if (bytes[0] == 0) return true;
+
+                // 10.0.0.0/8
+                if (bytes[0] == 10) return true;
+
+                // 100.64.0.0/10 (CGNAT)
+                if (bytes[0] == 100 && bytes[1] >= 64 && bytes[1] <= 127) return true;
+
+                // 127.0.0.0/8 (loopback)
+                if (bytes[0] == 127) return true;
+
+                // 169.254.0.0/16 (link-local)
+                if (bytes[0] == 169 && bytes[1] == 254) return true;
+
+                // 172.16.0.0/12
+                if (bytes[0] == 172 && bytes[1] >= 16 && bytes[1] <= 31) return true;
+
+                // 192.168.0.0/16
+                if (bytes[0] == 192 && bytes[1] == 168) return true;
+
+                // 224.0.0.0/4 (multicast) and 240.0.0.0/4 (reserved)
+                if (bytes[0] >= 224) return true;
+
+                return false;
+            }
+
+            if (address.AddressFamily == AddressFamily.InterNetworkV6)
+            {
+                if (address.IsIPv6LinkLocal || address.IsIPv6SiteLocal || address.IsIPv6Multicast)
+                {
+                    return true;
+                }
+
+                // ::/128 unspecified and ::1 loopback are already covered by IsLoopback / below.
+                if (address.Equals(IPAddress.IPv6Any) || address.Equals(IPAddress.IPv6Loopback))
+                {
+                    return true;
+                }
+
+                byte[] bytes = address.GetAddressBytes();
+
+                // fc00::/7 unique local addresses
+                if ((bytes[0] & 0xFE) == 0xFC)
+                {
+                    return true;
+                }
+
+                return false;
+            }
+
+            // Unknown address family: treat as unsafe.
+            return true;
+        }
+    }
+}

--- a/samples/TeamsSDK/Archived/connector-todo-notification/csharp/appsettings.json
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/csharp/appsettings.json
@@ -1,5 +1,16 @@
 {
   "BaseUrl": "<<BASE_URL>>",
   "ConnectorAppId": "<<CONNECTOR_ID>>",
-  "TenantId": "<<TENANT_ID>>"
+  "TenantId": "<<TENANT_ID>>",
+  "AzureAd": {
+    "Instance": "https://login.microsoftonline.com/",
+    "TenantId": "<<TENANT_ID>>",
+    "ClientId": "<<CLIENT_ID>>",
+    "ClientSecret": "<<CLIENT_SECRET>>",
+    "CallbackPath": "/signin-oidc"
+  },
+  "AllowedWebhookHostSuffixes": [
+    ".webhook.office.com",
+    ".logic.azure.com"
+  ]
 }

--- a/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/.env
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/.env
@@ -1,2 +1,4 @@
 MicrosoftAppId=
+MicrosoftAppTenantId=
 BaseUrl=
+AllowedWebhookHostSuffixes=.webhook.office.com,.logic.azure.com

--- a/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/Readme.md
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/Readme.md
@@ -6,6 +6,12 @@
 
 This sample provides a comprehensive guide to building an Office 365 Connector that sends task notifications to a Microsoft Teams channel. The app simulates a task management system where users can create, view, and update tasks, showcasing how to send notifications through connectors to enhance productivity in Teams.
 
+> [!IMPORTANT]
+> **Security notice**
+> * **Do not expose this sample anonymously.** The `/Connector/Save` and `/Task/Save` endpoints require a valid Microsoft Entra ID bearer token; configure `MicrosoftAppId` and `MicrosoftAppTenantId` in `.env` before running. Never deploy it as a public, unauthenticated endpoint.
+> * **Webhook destinations are restricted.** Registered webhook URLs are accepted only when they use HTTPS and match the `AllowedWebhookHostSuffixes` allow-list, and are blocked when they resolve to loopback, private (RFC1918), link-local, or other reserved addresses. This prevents Server-Side Request Forgery (SSRF). Outbound calls also disable HTTP redirects. Update the allow-list to match your own connector endpoints.
+> * Each registered webhook is bound to the authenticated user/tenant that created it, and notifications are sent only to the webhook owned by the current caller's context.
+
 ## Included Features
 * Connectors
 

--- a/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/authMiddleware.js
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/authMiddleware.js
@@ -1,0 +1,69 @@
+'use strict';
+
+const jwt = require('jsonwebtoken');
+const jwksClient = require('jwks-rsa');
+
+/**
+ * Middleware that requires a valid Microsoft Entra ID bearer token before an
+ * endpoint runs. This prevents anonymous callers from registering webhooks or
+ * triggering outbound notifications. The authenticated user's object id and
+ * tenant id are attached to req.user so webhooks can be bound to that context.
+ */
+
+const tenantId = process.env.MicrosoftAppTenantId || process.env.TenantId || 'common';
+const audience = process.env.MicrosoftAppId;
+
+const client = jwksClient({
+    jwksUri: `https://login.microsoftonline.com/${tenantId}/discovery/v2.0/keys`,
+    cache: true,
+    rateLimit: true
+});
+
+function getSigningKey(header, callback) {
+    client.getSigningKey(header.kid, (err, key) => {
+        if (err) {
+            callback(err);
+            return;
+        }
+        callback(null, key.getPublicKey());
+    });
+}
+
+function requireAuth(req, res, next) {
+    const authHeader = req.headers.authorization || '';
+    const match = authHeader.match(/^Bearer\s+(.+)$/i);
+    if (!match) {
+        res.status(401).json({ error: 'Missing bearer token.' });
+        return;
+    }
+
+    if (!audience) {
+        // Fail closed if the application is not configured for authentication.
+        res.status(500).json({ error: 'Authentication is not configured.' });
+        return;
+    }
+
+    const verifyOptions = {
+        audience: audience,
+        issuer: [
+            `https://login.microsoftonline.com/${tenantId}/v2.0`,
+            `https://sts.windows.net/${tenantId}/`
+        ],
+        algorithms: ['RS256']
+    };
+
+    jwt.verify(match[1], getSigningKey, verifyOptions, (err, decoded) => {
+        if (err) {
+            res.status(401).json({ error: 'Invalid bearer token.' });
+            return;
+        }
+
+        req.user = {
+            objectId: decoded.oid,
+            tenantId: decoded.tid
+        };
+        next();
+    });
+}
+
+module.exports = { requireAuth };

--- a/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/index.js
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/index.js
@@ -6,8 +6,29 @@ require('dotenv').config({ path: ENV_FILE });
 const PORT = process.env.PORT || 3978;
 const server = express();
 const axios = require('axios');
+const { validateWebhook } = require('./webhookValidator');
+const { requireAuth } = require('./authMiddleware');
 
-var webhookUrl = "";
+// Webhooks registered per authenticated connector context, keyed by "tenantId:objectId".
+var subscriptions = {};
+
+function ownerKey(user) {
+    return `${user.tenantId}:${user.objectId}`;
+}
+
+// Re-validates the destination immediately before the outbound call (defense in depth
+// against SSRF) and disables redirects so a trusted host cannot bounce to an internal target.
+async function postCard(url, card) {
+    const result = await validateWebhook(url);
+    if (!result.valid) {
+        return;
+    }
+    try {
+        await axios.post(url, card, { maxRedirects: 0 });
+    } catch (error) {
+        console.error(error.message);
+    }
+}
 
 var taskList = {
     "task": [
@@ -47,7 +68,7 @@ server.get('/TaskDetails', (req, res, next) => {
     res.render('./views/TaskDetails', { taskList: JSON.stringify(taskList) })
 });
 
-server.post('/Task/Save', (req, res, next) => {
+server.post('/Task/Save', requireAuth, (req, res, next) => {
     var task = {
         "Title": req.body.title,
         "Description": req.body.description,
@@ -88,15 +109,14 @@ server.post('/Task/Save', (req, res, next) => {
             }
         ]
     }
-    
-    axios.post(webhookUrl, card)
-        .then(res => {
-            console.log(`statusCode: ${res.status}`)
-            console.log(res)
-        })
-        .catch(error => {
-            console.error(error)
-        })
+
+    // Only notify the webhook registered by the current authenticated connector context.
+    const url = subscriptions[ownerKey(req.user)];
+    if (url) {
+        postCard(url, card);
+    }
+
+    res.json({ status: 'Task saved.' });
 });
 
 server.get('/Create', (req, res, next) => {
@@ -121,10 +141,19 @@ server.get('*', (req, res) => {
     res.json({ error: 'Route not found' });
 });
 
-server.post('/Connector/Save', (req, res) => {
+server.post('/Connector/Save', requireAuth, async (req, res) => {
+
+    // Validate the destination before storing or calling it to prevent SSRF (CWE-918).
+    const result = await validateWebhook(req.body.webhookUrl);
+    if (!result.valid) {
+        res.status(400).json({ error: result.reason });
+        return;
+    }
+
+    // Bind the webhook to the authenticated connector context (owner + tenant).
+    subscriptions[ownerKey(req.user)] = req.body.webhookUrl;
 
     var link = process.env.BaseUrl + "/TaskDetails"
-    webhookUrl = req.body.webhookUrl;
     var card = {
         "@type": "MessageCard",
         "summary": "Welcome Message",
@@ -134,13 +163,7 @@ server.post('/Connector/Save', (req, res) => {
         }]
     }
 
-    axios.post(req.body.webhookUrl, card)
-        .then(res => {
-            console.log(`statusCode: ${res.status}`)
-            console.log(res)
-        })
-        .catch(error => {
-            console.error(error)
-        })
+    await postCard(req.body.webhookUrl, card);
 
+    res.json({ status: 'Webhook registered.' });
 });

--- a/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/package-lock.json
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/package-lock.json
@@ -13,7 +13,9 @@
                 "cors": "^2.8.5",
                 "dotenv": "^16.4.7",
                 "ejs": "^3.1.10",
-                "express": "^4.22.2"
+                "express": "^4.22.2",
+                "jsonwebtoken": "^9.0.2",
+                "jwks-rsa": "^3.1.0"
             },
             "devDependencies": {
                 "esbuild": "^0.25.0",
@@ -656,6 +658,31 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/jsonwebtoken": {
+            "version": "9.0.10",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+            "integrity": "sha1-p5MqRxd9zUKDthRvO9XCbYJkfwk=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/ms": "*",
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha1-BSqmekjszEMJ1/AZG35BQ0uQu3g=",
+            "license": "MIT"
+        },
+        "node_modules/@types/node": {
+            "version": "26.1.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@types/node/-/node-26.1.2.tgz",
+            "integrity": "sha1-2nlwjx+cYpT0zeyPRVowMrAogIo=",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~8.3.0"
+            }
+        },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
@@ -1035,6 +1062,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/buffer-equal-constant-time": {
+            "version": "1.0.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+            "integrity": "sha1-+OcRMvf/5uAaXJaXpMbz5I1cyBk=",
+            "license": "BSD-3-Clause"
         },
         "node_modules/builtin-modules": {
             "version": "3.3.0",
@@ -1501,6 +1534,15 @@
             },
             "engines": {
                 "node": ">= 0.4"
+            }
+        },
+        "node_modules/ecdsa-sig-formatter": {
+            "version": "1.0.11",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+            "integrity": "sha1-rg8PothQRe8UqBfao86azQSJ5b8=",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
             }
         },
         "node_modules/ee-first": {
@@ -3430,6 +3472,15 @@
             "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
             "license": "MIT"
         },
+        "node_modules/jose": {
+            "version": "4.15.9",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jose/-/jose-4.15.9.tgz",
+            "integrity": "sha1-m2jtop6aBhTAQvopOHGWx92AAQA=",
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/panva"
+            }
+        },
         "node_modules/js-yaml": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3476,6 +3527,94 @@
                 "json5": "lib/cli.js"
             }
         },
+        "node_modules/jsonwebtoken": {
+            "version": "9.0.3",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+            "integrity": "sha1-bNV6sB6bCsB8uEfVPTybbuMfeuI=",
+            "license": "MIT",
+            "dependencies": {
+                "jws": "^4.0.1",
+                "lodash.includes": "^4.3.0",
+                "lodash.isboolean": "^3.0.3",
+                "lodash.isinteger": "^4.0.4",
+                "lodash.isnumber": "^3.0.3",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.isstring": "^4.0.1",
+                "lodash.once": "^4.0.0",
+                "ms": "^2.1.1",
+                "semver": "^7.5.4"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/jsonwebtoken/node_modules/semver": {
+            "version": "7.8.5",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/semver/-/semver-7.8.5.tgz",
+            "integrity": "sha1-ObZGA33VDBT7RR5+TKxY7YuGP2k=",
+            "license": "ISC",
+            "bin": {
+                "semver": "bin/semver.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/jwa": {
+            "version": "2.0.1",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jwa/-/jwa-2.0.1.tgz",
+            "integrity": "sha1-v4F20a0M1y4PP1gzhZWhPhELyAQ=",
+            "license": "MIT",
+            "dependencies": {
+                "buffer-equal-constant-time": "^1.0.1",
+                "ecdsa-sig-formatter": "1.0.11",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "node_modules/jwks-rsa": {
+            "version": "3.2.2",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
+            "integrity": "sha1-9tUoMGvvrNvGLIwCcnYfqsVf+7M=",
+            "license": "MIT",
+            "dependencies": {
+                "@types/jsonwebtoken": "^9.0.4",
+                "debug": "^4.3.4",
+                "jose": "^4.15.4",
+                "limiter": "^1.1.5",
+                "lru-memoizer": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/jwks-rsa/node_modules/debug": {
+            "version": "4.4.3",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha1-xq5DLZvZZiWC/OCHCbA4xY6ePWo=",
+            "license": "MIT",
+            "dependencies": {
+                "ms": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=6.0"
+            },
+            "peerDependenciesMeta": {
+                "supports-color": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jws": {
+            "version": "4.0.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/jws/-/jws-4.0.1.tgz",
+            "integrity": "sha1-B+3Bvo+sIOZ3soPs4mFJi9OPBpA=",
+            "license": "MIT",
+            "dependencies": {
+                "jwa": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -3500,6 +3639,11 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/limiter": {
+            "version": "1.1.5",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/limiter/-/limiter-1.1.5.tgz",
+            "integrity": "sha1-j5KiWzsWxhMSk6DMg0tKg4oqp8I="
+        },
         "node_modules/locate-path": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -3516,12 +3660,82 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/lodash.clonedeep": {
+            "version": "4.5.0",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+            "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
+            "license": "MIT"
+        },
+        "node_modules/lodash.includes": {
+            "version": "4.3.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.includes/-/lodash.includes-4.3.0.tgz",
+            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8=",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isboolean": {
+            "version": "3.0.3",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY=",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isinteger": {
+            "version": "4.0.4",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M=",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isnumber": {
+            "version": "3.0.3",
+            "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w=",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=",
+            "license": "MIT"
+        },
+        "node_modules/lodash.isstring": {
+            "version": "4.0.1",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE=",
+            "license": "MIT"
+        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/lodash.once": {
+            "version": "4.1.1",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lodash.once/-/lodash.once-4.1.1.tgz",
+            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=",
+            "license": "MIT"
+        },
+        "node_modules/lru-cache": {
+            "version": "6.0.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
+            "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+            "license": "ISC",
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/lru-memoizer": {
+            "version": "2.3.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
+            "integrity": "sha1-7w+8AhvOtmZ5SxRe76xr5J3EfzE=",
+            "license": "MIT",
+            "dependencies": {
+                "lodash.clonedeep": "^4.5.0",
+                "lru-cache": "6.0.0"
+            }
         },
         "node_modules/math-intrinsics": {
             "version": "1.1.0",
@@ -4992,6 +5206,12 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/undici-types": {
+            "version": "8.3.0",
+            "resolved": "https://ms-feed-17.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/undici-types/-/undici-types-8.3.0.tgz",
+            "integrity": "sha1-ROn8nzJEZIzeo15Pm7LWgelBCAk=",
+            "license": "MIT"
+        },
         "node_modules/unpipe": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -5146,6 +5366,12 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "dev": true,
+            "license": "ISC"
+        },
+        "node_modules/yallist": {
+            "version": "4.0.0",
+            "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/yallist/-/yallist-4.0.0.tgz",
+            "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
             "license": "ISC"
         },
         "node_modules/yocto-queue": {

--- a/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/package.json
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/package.json
@@ -21,7 +21,9 @@
         "cors": "^2.8.5",
         "dotenv": "^16.4.7",
         "ejs": "^3.1.10",
-        "express": "^4.22.2"
+        "express": "^4.22.2",
+        "jsonwebtoken": "^9.0.2",
+        "jwks-rsa": "^3.1.0"
     },
     "devDependencies": {
         "eslint": "^8.57.1",

--- a/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/webhookValidator.js
+++ b/samples/TeamsSDK/Archived/connector-todo-notification/nodejs/webhookValidator.js
@@ -1,0 +1,137 @@
+'use strict';
+
+const dns = require('dns').promises;
+const net = require('net');
+
+/**
+ * Validates webhook destinations before they are stored or called, to prevent
+ * Server-Side Request Forgery (SSRF, CWE-918). A destination is accepted only when
+ * it is an absolute HTTPS URL, its host matches a configured allow-list of trusted
+ * Microsoft connector endpoints, and none of the host's resolved IP addresses fall
+ * into loopback, private, link-local, or other special-use ranges.
+ */
+
+function getAllowedHostSuffixes() {
+    const raw = process.env.AllowedWebhookHostSuffixes || '.webhook.office.com,.logic.azure.com';
+    return raw
+        .split(',')
+        .map(s => s.trim())
+        .filter(s => s.length > 0);
+}
+
+function isHostAllowed(host, allowedHostSuffixes) {
+    if (!allowedHostSuffixes || allowedHostSuffixes.length === 0) {
+        // Fail closed: without a configured allow-list nothing is trusted.
+        return false;
+    }
+
+    const lowerHost = host.toLowerCase();
+    return allowedHostSuffixes.some(suffix => {
+        const normalized = suffix.toLowerCase();
+        const bare = normalized.replace(/^\./, '');
+        const dotted = normalized.startsWith('.') ? normalized : '.' + normalized;
+        return lowerHost === bare || lowerHost.endsWith(dotted);
+    });
+}
+
+function ipToBytes(ip) {
+    return ip.split('.').map(part => parseInt(part, 10));
+}
+
+function isPrivateOrReservedV4(ip) {
+    const b = ipToBytes(ip);
+    if (b.length !== 4 || b.some(n => Number.isNaN(n))) return true;
+
+    if (b[0] === 0) return true;                              // 0.0.0.0/8
+    if (b[0] === 10) return true;                             // 10.0.0.0/8
+    if (b[0] === 100 && b[1] >= 64 && b[1] <= 127) return true; // 100.64.0.0/10 CGNAT
+    if (b[0] === 127) return true;                            // 127.0.0.0/8 loopback
+    if (b[0] === 169 && b[1] === 254) return true;            // 169.254.0.0/16 link-local
+    if (b[0] === 172 && b[1] >= 16 && b[1] <= 31) return true; // 172.16.0.0/12
+    if (b[0] === 192 && b[1] === 168) return true;            // 192.168.0.0/16
+    if (b[0] >= 224) return true;                             // multicast + reserved
+    return false;
+}
+
+function isPrivateOrReservedV6(ip) {
+    const lower = ip.toLowerCase();
+
+    // IPv4-mapped IPv6 (::ffff:a.b.c.d) -> validate the embedded IPv4.
+    const mapped = lower.match(/^::ffff:(\d+\.\d+\.\d+\.\d+)$/);
+    if (mapped) {
+        return isPrivateOrReservedV4(mapped[1]);
+    }
+
+    if (lower === '::1') return true;   // loopback
+    if (lower === '::') return true;    // unspecified
+
+    if (lower.startsWith('fe8') || lower.startsWith('fe9') ||
+        lower.startsWith('fea') || lower.startsWith('feb')) {
+        return true;                    // fe80::/10 link-local
+    }
+    if (lower.startsWith('fc') || lower.startsWith('fd')) return true; // fc00::/7 ULA
+    if (lower.startsWith('ff')) return true;                           // ff00::/8 multicast
+
+    return false;
+}
+
+function isPrivateOrReserved(ip) {
+    const family = net.isIP(ip);
+    if (family === 4) return isPrivateOrReservedV4(ip);
+    if (family === 6) return isPrivateOrReservedV6(ip);
+    return true; // Unknown format: treat as unsafe.
+}
+
+/**
+ * Returns { valid: boolean, reason: string } for the supplied webhook URL.
+ */
+async function validateWebhook(webhookUrl, allowedHostSuffixes = getAllowedHostSuffixes()) {
+    if (!webhookUrl || typeof webhookUrl !== 'string' || webhookUrl.trim().length === 0) {
+        return { valid: false, reason: 'Webhook URL is empty.' };
+    }
+
+    let uri;
+    try {
+        uri = new URL(webhookUrl);
+    } catch (e) {
+        return { valid: false, reason: 'Webhook URL is not a valid absolute URL.' };
+    }
+
+    if (uri.protocol !== 'https:') {
+        return { valid: false, reason: 'Webhook URL must use the https scheme.' };
+    }
+
+    if (uri.username || uri.password) {
+        return { valid: false, reason: 'Webhook URL must not contain user information.' };
+    }
+
+    const host = uri.hostname;
+    if (!isHostAllowed(host, allowedHostSuffixes)) {
+        return { valid: false, reason: 'Webhook host is not in the allow-list of trusted connector endpoints.' };
+    }
+
+    let addresses;
+    try {
+        if (net.isIP(host)) {
+            addresses = [{ address: host }];
+        } else {
+            addresses = await dns.lookup(host, { all: true });
+        }
+    } catch (e) {
+        return { valid: false, reason: 'Webhook host could not be resolved.' };
+    }
+
+    if (!addresses || addresses.length === 0) {
+        return { valid: false, reason: 'Webhook host did not resolve to any address.' };
+    }
+
+    for (const entry of addresses) {
+        if (isPrivateOrReserved(entry.address)) {
+            return { valid: false, reason: 'Webhook host resolves to a private, loopback, or reserved address.' };
+        }
+    }
+
+    return { valid: true, reason: '' };
+}
+
+module.exports = { validateWebhook, getAllowedHostSuffixes };


### PR DESCRIPTION
## Summary
Hardens the archived `connector-todo-notification` sample (both C# and Node.js)
by adding authentication and outbound-destination validation to the webhook
registration and task-notification flows. Previously the sample accepted a
caller-supplied webhook URL with no authentication and no destination checks,
and made an outbound request to it — a defense-in-depth weakness for anyone who
deployed the sample as an internet-facing app.

## Changes

### Authentication & authorization
- **C#**: Added Microsoft Entra ID sign-in (`Microsoft.Identity.Web`) and a
  global fallback authorization policy so every endpoint requires an
  authenticated user by default. `ConnectorController` and `TaskController` are
  marked `[Authorize]`.
- **Node.js**: Added Entra ID bearer-token validation middleware (`jsonwebtoken`
  + `jwks-rsa`) applied to `/Connector/Save` and `/Task/Save`.

### Webhook destination validation (prevents SSRF)
- New `WebhookValidator` (C#) / `webhookValidator.js` (Node.js) that accepts a
  destination only when it:
  - uses the **https** scheme,
  - matches a configurable **host allow-list** (`AllowedWebhookHostSuffixes`),
  - resolves DNS and is **not** a loopback, private (RFC1918), CGNAT,
    link-local, or other reserved/special-use address (IPv4 + IPv6, including
    IPv4-mapped IPv6).
- Validation runs at registration **and** again immediately before each outbound
  call (defense in depth). The allow-list fails closed when unset.

### Redirect hardening
- Outbound calls disable automatic redirects (C# `AllowAutoRedirect = false`,
  Node.js `maxRedirects: 0`) so a trusted host cannot bounce the request to an
  internal target.

### Bind webhook to the authenticated context
- Each registered webhook is associated with the authenticated user/tenant, and
  notifications are delivered only to webhooks owned by the current caller's
  context.

### Additional fixes
- **C#** `TaskController.Update`: fixed the response-ordering bug (unawaited
  `WriteAsync` followed by a status mutation, previously `CS4014`) by sending
  notifications first and then awaiting the response write; switched header
  writes to the indexer.

### Documentation
- Added a security notice to both READMEs stating the sample must not be exposed
  anonymously, that it requires Entra ID configuration, and that webhook
  destinations are restricted to the configured allow-list over HTTPS.

## Configuration required to run
- **C#**: set the `AzureAd` section (`ClientId`, `TenantId`, `ClientSecret`) and
  `AllowedWebhookHostSuffixes` in `appsettings.json`.
- **Node.js**: set `MicrosoftAppId`, `MicrosoftAppTenantId`, and
  `AllowedWebhookHostSuffixes` in `.env`.

## Validation
- C#: `dotnet build` succeeds with no errors.
- Node.js: `npm install` succeeds; `node --check` passes for all changed files.